### PR TITLE
Fix build reliability and improve subtitle playback performance

### DIFF
--- a/src/JellyBox/App.xaml.cs
+++ b/src/JellyBox/App.xaml.cs
@@ -125,7 +125,7 @@ sealed partial class App : Application
     {
         try
         {
-            await _deviceProfileManager.InitializeAsync();
+            await _deviceProfileManager.EnsureInitializedAsync();
         }
         catch (Exception ex)
         {

--- a/src/JellyBox/Services/DeviceProfileManager.cs
+++ b/src/JellyBox/Services/DeviceProfileManager.cs
@@ -40,8 +40,30 @@ internal sealed class DeviceProfileManager
 
     public DeviceProfile Profile { get; private set; } = null!; // TODO
 
+    private Task? _initializationTask;
+
+    /// <summary>
+    /// Ensures the device profile has been built before playback requests.
+    /// Safe to call concurrently; initialization runs at most once until failure.
+    /// </summary>
+    public Task EnsureInitializedAsync()
+        => _initializationTask ??= InitializeInternalAsync();
+
+    private async Task InitializeInternalAsync()
+    {
+        try
+        {
+            await InitializeAsync();
+        }
+        catch
+        {
+            _initializationTask = null;
+            throw;
+        }
+    }
+
     // This logic is adapted from the web client's browserDeviceProfile.js
-    public async Task InitializeAsync()
+    private async Task InitializeAsync()
     {
         CodecQuery codecQuery = new();
 

--- a/src/JellyBox/ViewModels/VideoViewModel.MediaSource.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.MediaSource.cs
@@ -1,10 +1,12 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Kiota.Abstractions;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Media.Streaming.Adaptive;
 using Windows.Security.ExchangeActiveSyncProvisioning;
+using Windows.Storage.Streams;
 
 namespace JellyBox.ViewModels;
 
@@ -22,6 +24,7 @@ internal sealed partial class VideoViewModel
         int? subtitleStreamIndex,
         long? startTimeTicks)
     {
+        await _deviceProfileManager.EnsureInitializedAsync();
         DeviceProfile deviceProfile = _deviceProfileManager.Profile;
 
         // Note: This mutates the shared device profile. That's probably OK as long as all accesses do this.
@@ -99,8 +102,9 @@ internal sealed partial class VideoViewModel
 
         MediaSource mediaSource = await CreateMediaSourceAsync(mediaUri, isAdaptive);
 
-        // Add all external subtitles upfront for seamless switching
-        AddAllExternalSubtitles(mediaSource, mediaSourceInfo);
+        // Only load the selected external subtitle to avoid extra network I/O and parsing.
+        // Switching to a different external track restarts playback (see PopulateTrackLists).
+        await AddSelectedExternalSubtitleAsync(mediaSource, mediaSourceInfo);
 
         MediaPlaybackItem? playbackItem = new(mediaSource, startPosition);
 
@@ -117,49 +121,101 @@ internal sealed partial class VideoViewModel
     }
 
     /// <summary>
-    /// Adds all external subtitles in supported formats to the media source for seamless switching.
+    /// Adds the selected external subtitle in a supported format.
     /// UWP TimedTextSource only supports SRT (subrip) and VTT formats.
-    /// External subtitles are added in the same order as they appear in MediaStreams.
     /// </summary>
-    private void AddAllExternalSubtitles(MediaSource mediaSource, MediaSourceInfo mediaSourceInfo)
+    private async Task AddSelectedExternalSubtitleAsync(MediaSource mediaSource, MediaSourceInfo mediaSourceInfo)
     {
         if (mediaSourceInfo.MediaStreams is null)
         {
             return;
         }
 
-        foreach (MediaStream subtitleTrack in mediaSourceInfo.MediaStreams
-            .Where(s => s.Type == MediaStream_Type.Subtitle && s.IsExternal.GetValueOrDefault()))
+        int? selectedSubtitleIndex = _playbackProgressInfo?.SubtitleStreamIndex;
+        if (selectedSubtitleIndex is not >= 0)
         {
-            if (!IsSubtitleFormatSupported(subtitleTrack))
-            {
-                Debug.WriteLine($"Skipping unsupported external subtitle format: {subtitleTrack.Codec} (index {subtitleTrack.Index})");
-                continue;
-            }
+            return;
+        }
 
+        MediaStream? subtitleTrack = mediaSourceInfo.MediaStreams
+            .FirstOrDefault(s => s.Type == MediaStream_Type.Subtitle && s.Index == selectedSubtitleIndex);
+
+        if (subtitleTrack is null
+            || GetSubtitleDeliveryMethod(subtitleTrack) != MediaStream_DeliveryMethod.External)
+        {
+            return;
+        }
+
+        if (!IsSubtitleFormatSupported(subtitleTrack))
+        {
+            Debug.WriteLine($"Skipping unsupported external subtitle format: {subtitleTrack.Codec} (index {subtitleTrack.Index})");
+            return;
+        }
+
+        string language = subtitleTrack.Language ?? string.Empty;
+
+        if (subtitleTrack.IsExternalUrl.GetValueOrDefault())
+        {
             string? subtitleUrl = subtitleTrack.DeliveryUrl;
             if (string.IsNullOrEmpty(subtitleUrl))
             {
                 Debug.WriteLine($"Subtitle track {subtitleTrack.Index} has no delivery URL.");
-                continue;
+                return;
             }
 
-            if (!subtitleTrack.IsExternalUrl.GetValueOrDefault())
-            {
-                subtitleUrl = _sdkClientSettings.ServerUrl + subtitleUrl;
-            }
-
-            if (Uri.TryCreate(subtitleUrl, UriKind.Absolute, out Uri? subtitleUri))
-            {
-                TimedTextSource timedTextSource = TimedTextSource.CreateFromUri(subtitleUri);
-                mediaSource.ExternalTimedTextSources.Add(timedTextSource);
-                Debug.WriteLine($"Added external subtitle (index {subtitleTrack.Index}): {subtitleUri}");
-            }
-            else
-            {
-                Debug.WriteLine($"Failed to parse subtitle URL: {subtitleUrl}");
-            }
+            TimedTextSource timedTextSource = TimedTextSource.CreateFromUri(new Uri(subtitleUrl), language);
+            mediaSource.ExternalTimedTextSources.Add(timedTextSource);
+            Debug.WriteLine($"Added third-party external subtitle (index {subtitleTrack.Index}): {subtitleUrl}");
+            return;
         }
+
+        try
+        {
+            RequestInformation request = _jellyfinApiClient
+                .Videos[_currentItem!.Id!.Value]
+                [mediaSourceInfo.Id!]
+                .Subtitles[subtitleTrack.Index!.Value]
+                .StreamWithRouteFormat(GetSubtitleRouteFormat(subtitleTrack))
+                .ToGetRequestInformation();
+
+            using Stream responseStream = await _requestAdapter.SendPrimitiveAsync<Stream>(request)
+                ?? throw new InvalidOperationException("Subtitle stream response was null.");
+
+            using MemoryStream memoryStream = new();
+            await responseStream.CopyToAsync(memoryStream);
+            byte[] bytes = memoryStream.ToArray();
+#pragma warning disable CA2000 // MediaSource owns the stream for the lifetime of playback.
+            InMemoryRandomAccessStream stream = new();
+#pragma warning restore CA2000
+            await stream.WriteAsync(bytes.AsBuffer());
+            stream.Seek(0);
+
+            TimedTextSource timedTextSource = TimedTextSource.CreateFromStream(stream, language);
+            mediaSource.ExternalTimedTextSources.Add(timedTextSource);
+            Debug.WriteLine($"Added Jellyfin-hosted external subtitle from stream (index {subtitleTrack.Index})");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to download subtitle stream (index {subtitleTrack.Index}): {ex.Message}");
+        }
+    }
+
+    private static string GetSubtitleRouteFormat(MediaStream stream)
+    {
+        string codec = stream.Codec ?? string.Empty;
+        if (codec.Equals("subrip", StringComparison.OrdinalIgnoreCase)
+            || codec.Equals("srt", StringComparison.OrdinalIgnoreCase))
+        {
+            return "srt";
+        }
+
+        if (codec.Equals("vtt", StringComparison.OrdinalIgnoreCase)
+            || codec.Equals("webvtt", StringComparison.OrdinalIgnoreCase))
+        {
+            return "vtt";
+        }
+
+        return "srt";
     }
 
     private Uri? BuildMediaUri(MediaSourceInfo mediaSourceInfo)
@@ -199,6 +255,11 @@ internal sealed partial class VideoViewModel
 
     private async Task<int> DetectBitrateAsync()
     {
+        if (_cachedMaxStreamingBitrate.HasValue)
+        {
+            return _cachedMaxStreamingBitrate.Value;
+        }
+
         const int BitrateTestSize = 1024 * 1024; // 1MB
         const int DownloadChunkSize = 64 * 1024; // 64KB
         const double SafetyRatio = 0.8; // Only allow 80% of the detected bitrate to avoid buffering.
@@ -236,6 +297,7 @@ internal sealed partial class VideoViewModel
         double bytesPerSecond = totalBytesRead / responseTimeSeconds;
         int bitrate = (int)Math.Round(bytesPerSecond * 8 * SafetyRatio);
         Debug.WriteLine($"Downloaded {totalBytesRead} bytes in {responseTimeSeconds:F2}s. Using max bitrate of {bitrate}");
+        _cachedMaxStreamingBitrate = bitrate;
         return bitrate;
     }
 }

--- a/src/JellyBox/ViewModels/VideoViewModel.Playback.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Playback.cs
@@ -21,6 +21,7 @@ internal sealed partial class VideoViewModel
         {
             _transportControls = transportControls;
             _currentItem = parameters.Item;
+            _cachedMaxStreamingBitrate = null;
             BaseItemDto item = _currentItem;
             _playerElement = playerElement;
 

--- a/src/JellyBox/ViewModels/VideoViewModel.PlaybackInfo.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.PlaybackInfo.cs
@@ -127,7 +127,7 @@ internal sealed partial class VideoViewModel
                     {
                         info.AppendLine($"  Language: {subtitleStream.Language}");
                     }
-                    info.AppendLine($"  Delivery: {(subtitleStream.IsExternal == true ? "External" : "Embedded")}");
+                    info.AppendLine($"  Delivery: {subtitleStream.DeliveryMethod?.ToString() ?? (subtitleStream.IsExternal == true ? "External" : "Embedded")}");
                     info.AppendLine();
                 }
             }

--- a/src/JellyBox/ViewModels/VideoViewModel.Tracks.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Tracks.cs
@@ -42,8 +42,8 @@ internal sealed partial class VideoViewModel
         // UWP's TimedMetadataTracks collection orders embedded tracks first, then external tracks
         // in the order they were added to ExternalTimedTextSources.
         // See: https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/media-playback-with-mediasource
-        // We include ALL subtitles in the list, but only assign UwpTrackIndex to supported formats.
-        // Unsupported formats will trigger a playback restart to force server-side transcoding.
+        // UwpTrackIndex follows DeliveryMethod: Embed and the selected External track are presented
+        // client-side; other External tracks restart playback to load; Encode/Hls/Drop rely on the server.
         List<TrackInfo> subtitleTracks = [];
         int defaultSubtitleIndex = selectedSubtitleIndex ?? mediaSourceInfo.DefaultSubtitleStreamIndex ?? -1;
         int uwpSubtitleIndex = 0;
@@ -53,14 +53,14 @@ internal sealed partial class VideoViewModel
             .Where(s => s.Type == MediaStream_Type.Subtitle && !s.IsExternal.GetValueOrDefault()))
         {
             string displayName = stream.DisplayTitle ?? stream.Language ?? $"Track {stream.Index}";
-            bool isSupported = IsSubtitleFormatSupported(stream);
+            bool hasUwpTrack = HasClientSideUwpSubtitleTrack(stream, defaultSubtitleIndex);
 
             subtitleTracks.Add(new TrackInfo(
                 stream.Index!.Value,
-                isSupported ? uwpSubtitleIndex : null,
+                hasUwpTrack ? uwpSubtitleIndex : null,
                 displayName));
 
-            if (isSupported)
+            if (hasUwpTrack)
             {
                 uwpSubtitleIndex++;
             }
@@ -71,14 +71,14 @@ internal sealed partial class VideoViewModel
             .Where(s => s.Type == MediaStream_Type.Subtitle && s.IsExternal.GetValueOrDefault()))
         {
             string displayName = stream.DisplayTitle ?? stream.Language ?? $"Track {stream.Index}";
-            bool isSupported = IsSubtitleFormatSupported(stream);
+            bool hasUwpTrack = HasClientSideUwpSubtitleTrack(stream, defaultSubtitleIndex);
 
             subtitleTracks.Add(new TrackInfo(
                 stream.Index!.Value,
-                isSupported ? uwpSubtitleIndex : null,
+                hasUwpTrack ? uwpSubtitleIndex : null,
                 displayName));
 
-            if (isSupported)
+            if (hasUwpTrack)
             {
                 uwpSubtitleIndex++;
             }
@@ -90,11 +90,16 @@ internal sealed partial class VideoViewModel
 
     private void OnTimedMetadataTracksChanged(MediaPlaybackItem sender, IVectorChangedEventArgs args)
     {
+        if (args.CollectionChange != CollectionChange.ItemInserted)
+        {
+            return;
+        }
+
         // Capture the sender reference for use in the dispatcher callback
         MediaPlaybackItem playbackItem = sender;
 
         _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
-            CoreDispatcherPriority.Normal,
+            CoreDispatcherPriority.Low,
             () =>
             {
                 try
@@ -105,19 +110,43 @@ internal sealed partial class VideoViewModel
                         return;
                     }
 
-                    // Present the selected subtitle track if one is selected
-                    int selectedIndex = _playbackProgressInfo?.SubtitleStreamIndex ?? -1;
-                    int? uwpIndex = GetSubtitleUwpIndex(selectedIndex);
-                    if (uwpIndex.HasValue && uwpIndex.Value < playbackItem.TimedMetadataTracks.Count)
-                    {
-                        playbackItem.TimedMetadataTracks.SetPresentationMode((uint)uwpIndex.Value, TimedMetadataTrackPresentationMode.PlatformPresented);
-                    }
+                    PresentSelectedSubtitleTrack(playbackItem);
                 }
                 catch (Exception ex)
                 {
                     Debug.WriteLine($"Error in OnTimedMetadataTracksChanged: {ex}");
                 }
             });
+    }
+
+    private void PresentSelectedSubtitleTrack(MediaPlaybackItem playbackItem)
+    {
+        int selectedIndex = _playbackProgressInfo?.SubtitleStreamIndex ?? -1;
+        if (selectedIndex < 0)
+        {
+            for (uint i = 0; i < playbackItem.TimedMetadataTracks.Count; i++)
+            {
+                playbackItem.TimedMetadataTracks.SetPresentationMode(i, TimedMetadataTrackPresentationMode.Disabled);
+            }
+
+            return;
+        }
+
+        int? uwpIndex = GetSubtitleUwpIndex(selectedIndex);
+        if (!uwpIndex.HasValue || uwpIndex.Value >= playbackItem.TimedMetadataTracks.Count)
+        {
+            Debug.WriteLine(
+                $"Subtitle UWP index out of range for Jellyfin index {selectedIndex} (uwp={uwpIndex}, count={playbackItem.TimedMetadataTracks.Count}).");
+            return;
+        }
+
+        for (uint i = 0; i < playbackItem.TimedMetadataTracks.Count; i++)
+        {
+            var mode = i == uwpIndex.Value
+                ? TimedMetadataTrackPresentationMode.PlatformPresented
+                : TimedMetadataTrackPresentationMode.Disabled;
+            playbackItem.TimedMetadataTracks.SetPresentationMode(i, mode);
+        }
     }
 
     /// <summary>
@@ -162,24 +191,46 @@ internal sealed partial class VideoViewModel
 
         if (canSeamlessSwitch)
         {
-            // Set each track's presentation mode in a single pass
-            for (uint i = 0; i < _currentPlaybackItem!.TimedMetadataTracks.Count; i++)
-            {
-                var mode = i == track.UwpTrackIndex
-                    ? TimedMetadataTrackPresentationMode.PlatformPresented
-                    : TimedMetadataTrackPresentationMode.Disabled;
-                _currentPlaybackItem.TimedMetadataTracks.SetPresentationMode(i, mode);
-            }
-
+            PresentSelectedSubtitleTrack(_currentPlaybackItem!);
             Debug.WriteLine(track.UwpTrackIndex.HasValue
                 ? $"Seamless subtitle switch to Jellyfin index {track.JellyfinIndex} (UWP index {track.UwpTrackIndex})"
                 : "Subtitles disabled");
             return;
         }
 
-        // Fall back to restarting playback (e.g., for transcoding scenarios or unsupported formats)
+        // Fall back to restarting playback (e.g., switching unloaded external tracks, transcoding, unsupported formats)
         Debug.WriteLine($"Restarting playback for subtitle track {track.JellyfinIndex}");
         RestartPlaybackWithCurrentPosition();
+    }
+
+    /// <summary>
+    /// Returns whether the stream has a UWP TimedMetadataTrack that can be toggled without restarting playback.
+    /// </summary>
+    private static bool HasClientSideUwpSubtitleTrack(MediaStream stream, int selectedSubtitleIndex)
+    {
+        if (!IsSubtitleFormatSupported(stream))
+        {
+            return false;
+        }
+
+        return GetSubtitleDeliveryMethod(stream) switch
+        {
+            MediaStream_DeliveryMethod.Embed => true,
+            MediaStream_DeliveryMethod.External => stream.Index == selectedSubtitleIndex,
+            _ => false,
+        };
+    }
+
+    private static MediaStream_DeliveryMethod GetSubtitleDeliveryMethod(MediaStream stream)
+    {
+        if (stream.DeliveryMethod.HasValue)
+        {
+            return stream.DeliveryMethod.Value;
+        }
+
+        return stream.IsExternal.GetValueOrDefault()
+            ? MediaStream_DeliveryMethod.External
+            : MediaStream_DeliveryMethod.Embed;
     }
 
     /// <summary>

--- a/src/JellyBox/ViewModels/VideoViewModel.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.cs
@@ -3,6 +3,7 @@ using JellyBox.Controls;
 using JellyBox.Services;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Kiota.Abstractions;
 using Windows.Media.Playback;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -14,6 +15,7 @@ internal sealed partial class VideoViewModel : ObservableObject
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
     private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly IRequestAdapter _requestAdapter;
     private readonly JellyfinImageResolver _imageResolver;
     private readonly JellyfinSdkSettings _sdkClientSettings;
     private readonly DeviceProfileManager _deviceProfileManager;
@@ -26,14 +28,17 @@ internal sealed partial class VideoViewModel : ObservableObject
     private MediaPlaybackItem? _currentPlaybackItem;
     private double _volumeBeforeMute = 1.0;
     private bool _isDirectPlay;
+    private int? _cachedMaxStreamingBitrate;
 
     public VideoViewModel(
         JellyfinApiClient jellyfinApiClient,
+        IRequestAdapter requestAdapter,
         JellyfinImageResolver imageResolver,
         JellyfinSdkSettings sdkClientSettings,
         DeviceProfileManager deviceProfileManager)
     {
         _jellyfinApiClient = jellyfinApiClient;
+        _requestAdapter = requestAdapter;
         _imageResolver = imageResolver;
         _sdkClientSettings = sdkClientSettings;
         _deviceProfileManager = deviceProfileManager;


### PR DESCRIPTION
## Summary

Improves subtitle playback performance during direct play.

Rebased onto `main`; build/restore changes were dropped (addressed upstream in #90 and #92).

## Subtitle playback

Fixes noticeable lag/stutter when subtitles are enabled during otherwise smooth direct play.

- **Load only the selected external subtitle** instead of fetching/parsing every external track up front.
- **Authenticated Jellyfin-hosted external subtitles:** Download via injected `IRequestAdapter.SendPrimitiveAsync` and `TimedTextSource.CreateFromStream`; third-party URLs use `CreateFromUri` without appending an API key.
- **Route by `DeliveryMethod`:** Embedded and the selected external track are presented client-side; switching to another unloaded external track restarts playback to load it.
- **Cache bitrate test** for the duration of a playback session (avoids repeated 1MB download tests on track restarts).
- **Subtitle presentation:** Consolidate track presentation logic and reduce `TimedMetadataTracksChanged` dispatcher churn.
- **Device profile init:** Ensure profile is ready before playback info requests.

## Test plan

- [x] Build succeeds locally with VS 2026 + UWP workload (`Release | x64`)
- [x] App launches and connects to Jellyfin server
- [x] Video direct play works with subtitles off
- [x] Subtitle toggle/selection plays smoothly (no severe lag) with embedded and external SRT/VTT
- [x] Seamless subtitle track switching still works where supported (embedded; selected external)

## Notes

Tested on Windows (desktop deployment). Intended to benefit Xbox Series X/S as well.