### PR TITLE
Build fixes, Xbox controller support, and movie/TV search

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
+    <!-- Pin CPM file location for Visual Studio (nested project under src/) -->
+    <DirectoryPackagesPropsPath>$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildProjectDirectory)'))</DirectoryPackagesPropsPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Be strict with warnings -->
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,12 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.22.0" />
     <PackageVersion Include="Microsoft.UI.Xaml" Version="2.8.7" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="3.0.1" />

--- a/src/JellyBox/App.xaml.cs
+++ b/src/JellyBox/App.xaml.cs
@@ -40,9 +40,20 @@ sealed partial class App : Application
 
         InitializeComponent();
 
+        UnhandledException += OnUnhandledException;
+
         Current.RequiresPointerMode = ApplicationRequiresPointerMode.WhenRequested;
 
         Suspending += OnSuspending;
+    }
+
+    private void OnUnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine($"Unhandled UI exception: {e.Exception}");
+        if (e.Exception.InnerException is not null)
+        {
+            System.Diagnostics.Debug.WriteLine($"Inner exception: {e.Exception.InnerException}");
+        }
     }
 
     /// <inheritdoc/>

--- a/src/JellyBox/AppServices.cs
+++ b/src/JellyBox/AppServices.cs
@@ -71,6 +71,8 @@ internal sealed class AppServices
         serviceCollection.AddTransient<LibraryViewModel>();
         serviceCollection.AddTransient<LoginViewModel>();
         serviceCollection.AddTransient<MainPageViewModel>();
+        serviceCollection.AddTransient<SearchViewModel>();
+        serviceCollection.AddTransient<ShellSearchViewModel>();
         serviceCollection.AddTransient<ServerSelectionViewModel>();
         serviceCollection.AddTransient<VideoViewModel>();
         serviceCollection.AddTransient<WebVideoViewModel>();

--- a/src/JellyBox/AppServices.cs
+++ b/src/JellyBox/AppServices.cs
@@ -64,6 +64,7 @@ internal sealed class AppServices
         serviceCollection.AddSingleton<DeviceProfileManager>();
         serviceCollection.AddSingleton<JellyfinImageResolver>();
         serviceCollection.AddSingleton<NavigationManager>();
+        serviceCollection.AddSingleton<ShellFocusCoordinator>();
 
         // View Models
         serviceCollection.AddTransient<HomeViewModel>();

--- a/src/JellyBox/Behaviors/FocusFirstItemBehavior.cs
+++ b/src/JellyBox/Behaviors/FocusFirstItemBehavior.cs
@@ -8,7 +8,9 @@ namespace JellyBox.Behaviors;
 /// <summary>
 /// Automatically focuses the first item in a list once items are loaded and containers are realized.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class FocusFirstItemBehavior : Behavior<ListViewBase>
+#pragma warning restore CA1812
 {
     private bool _hasFocused;
 

--- a/src/JellyBox/Behaviors/FocusOnLoadBehavior.cs
+++ b/src/JellyBox/Behaviors/FocusOnLoadBehavior.cs
@@ -4,7 +4,9 @@ using Windows.UI.Xaml.Controls;
 
 namespace JellyBox.Behaviors;
 
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class FocusOnLoadBehavior : Behavior<Control>
+#pragma warning restore CA1812
 {
     protected override void OnAttached()
     {

--- a/src/JellyBox/Behaviors/ListViewBaseCommandBehavior.cs
+++ b/src/JellyBox/Behaviors/ListViewBaseCommandBehavior.cs
@@ -7,7 +7,9 @@ namespace JellyBox.Behaviors;
 /// <summary>
 /// Invokes the NavigateCommand on INavigable items when they are clicked in a ListViewBase control.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class ListViewBaseCommandBehavior : Behavior<ListViewBase>
+#pragma warning restore CA1812
 {
     protected override void OnAttached()
     {

--- a/src/JellyBox/Behaviors/ScrollOnFocusBehavior.cs
+++ b/src/JellyBox/Behaviors/ScrollOnFocusBehavior.cs
@@ -11,7 +11,9 @@ namespace JellyBox.Behaviors;
 /// Adjusts scroll position to keep focused items within the TV-safe zone.
 /// Supports both horizontal carousels and full grid layouts.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class ScrollOnFocusBehavior : Behavior<ListViewBase>
+#pragma warning restore CA1812
 {
     private ScrollViewer? _scrollViewer;
 

--- a/src/JellyBox/Behaviors/SectionNavigationBehavior.cs
+++ b/src/JellyBox/Behaviors/SectionNavigationBehavior.cs
@@ -1,3 +1,6 @@
+using JellyBox;
+using JellyBox.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Xaml.Interactivity;
 using Windows.Foundation;
 using Windows.UI.Core;
@@ -11,7 +14,9 @@ namespace JellyBox.Behaviors;
 /// Handles vertical navigation between horizontal list rows within a sections container.
 /// Maintains horizontal position when moving between rows and handles edge trapping.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class SectionNavigationBehavior : Behavior<ItemsControl>
+#pragma warning restore CA1812
 {
     private ScrollViewer? _scrollViewer;
 
@@ -102,7 +107,11 @@ internal sealed class SectionNavigationBehavior : Behavior<ItemsControl>
         {
             if (TrapAtTop)
             {
-                e.TryCancel();
+                ShellFocusCoordinator shellFocus = AppServices.Instance.ServiceProvider.GetRequiredService<ShellFocusCoordinator>();
+                if (shellFocus.TryFocusSearch())
+                {
+                    e.TryCancel();
+                }
             }
 
             return;

--- a/src/JellyBox/Glyphs.cs
+++ b/src/JellyBox/Glyphs.cs
@@ -7,6 +7,7 @@ internal static class Glyphs
 {
     // Navigation
     public const string Home = "\uE80F";
+    public const string Search = "\uE721";
     public const string Library = "\uE8F1";
     public const string Switch = "\uE895";
     public const string SignOut = "\uE8BB";

--- a/src/JellyBox/JellyBox.csproj
+++ b/src/JellyBox/JellyBox.csproj
@@ -9,7 +9,7 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PublishAot>true</PublishAot>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <PublishProfile Condition="'$(PublishProfile)' == '' and '$(Platform)' == 'x64'">win-x64.pubxml</PublishProfile>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     <DisableEmbeddedXbf>true</DisableEmbeddedXbf>
     <EnableMsixTooling>true</EnableMsixTooling>
@@ -47,10 +47,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="SetAppxManifestVersion"
-          BeforeTargets="PrepareForBuild"
-          DependsOnTargets="EnsureBuildVersion"
-          Condition="Exists('$(MSBuildProjectDirectory)\Package.appxmanifest')">
+  <Target Name="SetAppxManifestVersion" BeforeTargets="PrepareForBuild" DependsOnTargets="EnsureBuildVersion" Condition="Exists('$(MSBuildProjectDirectory)\Package.appxmanifest')">
     <PropertyGroup>
       <_AppxManifestSource>$(MSBuildProjectDirectory)\Package.appxmanifest</_AppxManifestSource>
       <_AppxManifestIntermediate>$(IntermediateOutputPath)Package.appxmanifest</_AppxManifestIntermediate>
@@ -62,22 +59,11 @@
       </AppxManifestNamespaces>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
-    <Copy
-      SourceFiles="$(_AppxManifestSource)"
-      DestinationFiles="$(_AppxManifestIntermediate)"
-      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
-      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
-      Retries="$(CopyRetryCount)"
-      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)" />
+    <Copy SourceFiles="$(_AppxManifestSource)" DestinationFiles="$(_AppxManifestIntermediate)" SkipUnchangedFiles="$(SkipCopyUnchangedFiles)" OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)" Retries="$(CopyRetryCount)" RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)" />
     <ItemGroup>
       <AppxManifest Remove="@(AppxManifest)" />
       <AppxManifest Include="$(_AppxManifestIntermediate)" />
     </ItemGroup>
-    <XmlPoke
-      XmlInputPath="$(_AppxManifestIntermediate)"
-      Value="$(BuildVersion)"
-      Query="/dn:Package/dn:Identity/@Version"
-      Namespaces="$(AppxManifestNamespaces)" />
+    <XmlPoke XmlInputPath="$(_AppxManifestIntermediate)" Value="$(BuildVersion)" Query="/dn:Package/dn:Identity/@Version" Namespaces="$(AppxManifestNamespaces)" />
   </Target>
 </Project>

--- a/src/JellyBox/JellyBox.csproj
+++ b/src/JellyBox/JellyBox.csproj
@@ -39,36 +39,45 @@
     <PackageReference Include="Microsoft.Web.WebView2" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" />
   </ItemGroup>
+
+  <!-- Fallback when Nerdbank.GitVersioning targets are not yet restored (e.g. first VS load) -->
+  <Target Name="EnsureBuildVersion" BeforeTargets="SetAppxManifestVersion">
+    <PropertyGroup Condition="'$(BuildVersion)' == ''">
+      <BuildVersion>0.1.0.0</BuildVersion>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="SetAppxManifestVersion"
           BeforeTargets="PrepareForBuild"
-          DependsOnTargets="GetBuildVersion">
-    <ItemGroup>
-      <_OriginalAppxManifest Include="@(AppxManifest)" />
-      <AppxManifest Remove="@(AppxManifest)" />
-      <AppxManifest Include="@(_OriginalAppxManifest -> '$(IntermediateOutputPath)%(Filename)%(Extension)')" />
-    </ItemGroup>
+          DependsOnTargets="EnsureBuildVersion"
+          Condition="Exists('$(MSBuildProjectDirectory)\Package.appxmanifest')">
+    <PropertyGroup>
+      <_AppxManifestSource>$(MSBuildProjectDirectory)\Package.appxmanifest</_AppxManifestSource>
+      <_AppxManifestIntermediate>$(IntermediateOutputPath)Package.appxmanifest</_AppxManifestIntermediate>
+      <AppxManifestNamespaces>
+        <Namespace Prefix="dn" Uri="http://schemas.microsoft.com/appx/manifest/foundation/windows10" />
+        <Namespace Prefix="mp" Uri="http://schemas.microsoft.com/appx/2014/phone/manifest" />
+        <Namespace Prefix="uap" Uri="http://schemas.microsoft.com/appx/manifest/uap/windows10" />
+        <Namespace Prefix="rescap" Uri="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" />
+      </AppxManifestNamespaces>
+    </PropertyGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
     <Copy
-      SourceFiles="@(_OriginalAppxManifest)"
-      DestinationFiles="@(AppxManifest)"
+      SourceFiles="$(_AppxManifestSource)"
+      DestinationFiles="$(_AppxManifestIntermediate)"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"
       RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)"
-      />
-    <PropertyGroup>
-      <AppxManifestNamespaces>
-          <Namespace Prefix="dn" Uri="http://schemas.microsoft.com/appx/manifest/foundation/windows10" />
-          <Namespace Prefix="mp" Uri="http://schemas.microsoft.com/appx/2014/phone/manifest" />
-          <Namespace Prefix="uap" Uri="http://schemas.microsoft.com/appx/manifest/uap/windows10" />
-          <Namespace Prefix="rescap" Uri="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" />
-      </AppxManifestNamespaces>
-    </PropertyGroup>
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)" />
+    <ItemGroup>
+      <AppxManifest Remove="@(AppxManifest)" />
+      <AppxManifest Include="$(_AppxManifestIntermediate)" />
+    </ItemGroup>
     <XmlPoke
-      XmlInputPath="@(AppxManifest)"
+      XmlInputPath="$(_AppxManifestIntermediate)"
       Value="$(BuildVersion)"
       Query="/dn:Package/dn:Identity/@Version"
-      Namespaces="$(AppxManifestNamespaces)"
-      />
-    </Target>
+      Namespaces="$(AppxManifestNamespaces)" />
+  </Target>
 </Project>

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -23,12 +23,14 @@
                 x:Name="SearchBox"
                 MaxWidth="720"
                 HorizontalAlignment="Stretch"
+                IsTabStop="False"
                 PlaceholderText="Search movies and TV shows"
                 Style="{StaticResource SearchAutoSuggestBox}"
                 ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
                 TextChanged="SearchBox_TextChanged"
                 QuerySubmitted="SearchBox_QuerySubmitted"
                 SuggestionChosen="SearchBox_SuggestionChosen"
+                LostFocus="SearchBox_LostFocus"
                 XYFocusKeyboardNavigation="Enabled">
                 <AutoSuggestBox.QueryIcon>
                     <SymbolIcon Symbol="Find" />

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -24,7 +24,6 @@
                 MaxWidth="720"
                 HorizontalAlignment="Stretch"
                 PlaceholderText="Search movies and TV shows"
-                TextMemberPath="DisplayText"
                 Style="{StaticResource SearchAutoSuggestBox}"
                 ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
                 TextChanged="SearchBox_TextChanged"

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -2,13 +2,61 @@
     x:Class="JellyBox.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:JellyBox.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{StaticResource BackgroundBase}">
 
     <Grid XYFocusKeyboardNavigation="Enabled">
-        <Frame x:Name="ContentFrame" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid
+            Grid.Row="0"
+            Padding="48,20,48,12"
+            Background="{StaticResource BackgroundBase}"
+            XYFocusKeyboardNavigation="Enabled">
+            <AutoSuggestBox
+                x:Name="SearchBox"
+                MaxWidth="720"
+                HorizontalAlignment="Stretch"
+                PlaceholderText="Search movies and TV shows"
+                QueryIcon="Find"
+                Style="{StaticResource SearchAutoSuggestBox}"
+                Text="{x:Bind ViewModel.Search.Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
+                QuerySubmitted="SearchBox_QuerySubmitted"
+                SuggestionChosen="SearchBox_SuggestionChosen"
+                XYFocusKeyboardNavigation="Enabled">
+                <AutoSuggestBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:SearchSuggestion">
+                        <StackPanel Orientation="Horizontal" Spacing="12" Padding="4,10">
+                            <FontIcon
+                                FontFamily="{StaticResource SegoeIcons}"
+                                Glyph="&#xE721;"
+                                FontSize="16"
+                                Foreground="{StaticResource TextMuted}"
+                                VerticalAlignment="Center" />
+                            <StackPanel Spacing="2" VerticalAlignment="Center">
+                                <TextBlock
+                                    Text="{x:Bind DisplayText}"
+                                    FontSize="{StaticResource FontS}"
+                                    Foreground="{StaticResource TextPrimary}" />
+                                <TextBlock
+                                    Text="{x:Bind SecondaryText}"
+                                    FontSize="{StaticResource FontXS}"
+                                    Foreground="{StaticResource TextMuted}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+            </AutoSuggestBox>
+        </Grid>
+
+        <Frame x:Name="ContentFrame" Grid.Row="1" />
 
         <Grid
             x:Name="NavigationOverlay"

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -24,13 +24,16 @@
                 MaxWidth="720"
                 HorizontalAlignment="Stretch"
                 PlaceholderText="Search movies and TV shows"
-                QueryIcon="Find"
+                TextMemberPath="DisplayText"
                 Style="{StaticResource SearchAutoSuggestBox}"
-                Text="{x:Bind ViewModel.Search.Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
+                TextChanged="SearchBox_TextChanged"
                 QuerySubmitted="SearchBox_QuerySubmitted"
                 SuggestionChosen="SearchBox_SuggestionChosen"
                 XYFocusKeyboardNavigation="Enabled">
+                <AutoSuggestBox.QueryIcon>
+                    <SymbolIcon Symbol="Find" />
+                </AutoSuggestBox.QueryIcon>
                 <AutoSuggestBox.ItemTemplate>
                     <DataTemplate x:DataType="models:SearchSuggestion">
                         <StackPanel Orientation="Horizontal" Spacing="12" Padding="4,10">
@@ -60,6 +63,8 @@
 
         <Grid
             x:Name="NavigationOverlay"
+            Grid.Row="0"
+            Grid.RowSpan="2"
             Visibility="Collapsed"
             XYFocusKeyboardNavigation="Enabled">
 

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,6 +1,5 @@
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -22,8 +21,6 @@ internal sealed partial class MainPage : Page
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
-
-        KeyDown += OnKeyDown;
 
         SlideInAnimation.Completed += SlideInCompleted;
 
@@ -112,88 +109,6 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
-    }
-
-    /// <summary>
-    /// Keyboard and gamepad input handling.
-    /// Only handles commands and nav-menu-specific logic.
-    /// Directional focus movement is handled by XYFocusKeyboardNavigation in XAML.
-    /// </summary>
-    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        // Don't intercept keys when a text input control has focus
-        if (FocusManager.GetFocusedElement() is TextBox or PasswordBox)
-        {
-            return;
-        }
-
-        switch (e.Key)
-        {
-            // Back gesture - close navigation if open
-            case VirtualKey.Back:
-            case VirtualKey.GamepadB:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Toggle navigation menu
-            case VirtualKey.GamepadMenu:
-            case VirtualKey.GamepadView:
-            case VirtualKey.M:
-            {
-                ViewModel.ToggleNavigationCommand.Execute(null);
-                e.Handled = true;
-                break;
-            }
-
-            // Close navigation menu
-            case VirtualKey.Escape:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Right closes nav menu when open
-            case VirtualKey.Right:
-            case VirtualKey.GamepadDPadRight:
-            case VirtualKey.GamepadLeftThumbstickRight:
-            case VirtualKey.NavigationRight:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Left at edge opens nav menu
-            case VirtualKey.Left:
-            case VirtualKey.GamepadDPadLeft:
-            case VirtualKey.GamepadLeftThumbstickLeft:
-            case VirtualKey.NavigationLeft:
-            {
-                if (!ViewModel.IsMenuOpen && !FocusManager.TryMoveFocus(FocusNavigationDirection.Left))
-                {
-                    ViewModel.OpenNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-        }
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using JellyBox.Models;
+using JellyBox.Services;
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.UI.Core;
@@ -15,10 +16,14 @@ internal sealed partial class MainPage : Page
     private FrameworkElement? _lastFocusedElement;
     private bool _ignoreNextQuerySubmitted;
     private bool _suppressSearchTextSync;
+    private readonly ShellFocusCoordinator _shellFocus;
 
     public MainPage()
     {
         InitializeComponent();
+
+        _shellFocus = AppServices.Instance.ServiceProvider.GetRequiredService<ShellFocusCoordinator>();
+        _shellFocus.RegisterSearchBox(SearchBox);
 
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<MainPageViewModel>();
         ViewModel.IsMenuOpenChanged += OnIsMenuOpenChanged;
@@ -107,9 +112,15 @@ internal sealed partial class MainPage : Page
             CoreDispatcherPriority.Normal,
             () =>
             {
+                _shellFocus.OnContentNavigated();
                 ViewModel.CloseNavigationCommand.Execute(null);
                 ViewModel.UpdateSelectedMenuItem();
             });
+    }
+
+    private void SearchBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        _shellFocus.OnSearchDismissed();
     }
 
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using JellyBox.Models;
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,7 @@ internal sealed partial class MainPage : Page
 
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<MainPageViewModel>();
         ViewModel.IsMenuOpenChanged += OnIsMenuOpenChanged;
+        ViewModel.Search.PropertyChanged += OnSearchPropertyChanged;
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
@@ -34,6 +36,7 @@ internal sealed partial class MainPage : Page
         Unloaded += (sender, e) =>
         {
             ContentFrame.Navigated -= ContentFrameNavigated;
+            ViewModel.Search.PropertyChanged -= OnSearchPropertyChanged;
         };
     }
 
@@ -110,6 +113,23 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
+    }
+
+    private void OnSearchPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ShellSearchViewModel.Query)
+            && SearchBox.Text != ViewModel.Search.Query)
+        {
+            SearchBox.Text = ViewModel.Search.Query;
+        }
+    }
+
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+        {
+            ViewModel.Search.Query = sender.Text ?? string.Empty;
+        }
     }
 
     private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,3 +1,4 @@
+using JellyBox.Models;
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.UI.Core;
@@ -109,6 +110,25 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
+    }
+
+    private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        if (args.ChosenSuggestion is SearchSuggestion suggestion)
+        {
+            ViewModel.Search.SelectSuggestion(suggestion);
+            return;
+        }
+
+        ViewModel.Search.SubmitQuery(args.QueryText);
+    }
+
+    private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        if (args.SelectedItem is SearchSuggestion suggestion)
+        {
+            ViewModel.Search.SelectSuggestion(suggestion);
+        }
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -14,6 +14,7 @@ internal sealed partial class MainPage : Page
 {
     private FrameworkElement? _lastFocusedElement;
     private bool _ignoreNextQuerySubmitted;
+    private bool _suppressSearchTextSync;
 
     public MainPage()
     {
@@ -118,11 +119,14 @@ internal sealed partial class MainPage : Page
 
     private void OnSearchPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(ShellSearchViewModel.Query)
-            && SearchBox.Text != ViewModel.Search.Query)
+        if (_suppressSearchTextSync
+            || e.PropertyName is not nameof(ShellSearchViewModel.Query)
+            || SearchBox.Text == ViewModel.Search.Query)
         {
-            SearchBox.Text = ViewModel.Search.Query;
+            return;
         }
+
+        SearchBox.Text = ViewModel.Search.Query;
     }
 
     private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
@@ -143,7 +147,7 @@ internal sealed partial class MainPage : Page
 
         if (args.ChosenSuggestion is SearchSuggestion suggestion)
         {
-            ViewModel.Search.OpenSuggestion(suggestion);
+            OpenSearchSuggestion(suggestion);
             return;
         }
 
@@ -154,9 +158,30 @@ internal sealed partial class MainPage : Page
     {
         if (args.SelectedItem is SearchSuggestion suggestion)
         {
-            _ignoreNextQuerySubmitted = true;
-            ViewModel.Search.OpenSuggestion(suggestion);
+            OpenSearchSuggestion(suggestion);
         }
+    }
+
+    private void OpenSearchSuggestion(SearchSuggestion suggestion)
+    {
+        _ignoreNextQuerySubmitted = true;
+        ViewModel.Search.PrepareSuggestionNavigation();
+        ViewModel.Search.ClearSuggestions();
+
+        _ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+        {
+            _suppressSearchTextSync = true;
+            try
+            {
+                ViewModel.Search.SetQueryText(suggestion.DisplayText);
+                SearchBox.Text = suggestion.DisplayText;
+                ViewModel.Search.NavigateToItem(suggestion.ItemId);
+            }
+            finally
+            {
+                _suppressSearchTextSync = false;
+            }
+        });
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -13,6 +13,7 @@ namespace JellyBox;
 internal sealed partial class MainPage : Page
 {
     private FrameworkElement? _lastFocusedElement;
+    private bool _ignoreNextQuerySubmitted;
 
     public MainPage()
     {
@@ -134,9 +135,15 @@ internal sealed partial class MainPage : Page
 
     private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
     {
+        if (_ignoreNextQuerySubmitted)
+        {
+            _ignoreNextQuerySubmitted = false;
+            return;
+        }
+
         if (args.ChosenSuggestion is SearchSuggestion suggestion)
         {
-            ViewModel.Search.SelectSuggestion(suggestion);
+            ViewModel.Search.OpenSuggestion(suggestion);
             return;
         }
 
@@ -147,7 +154,8 @@ internal sealed partial class MainPage : Page
     {
         if (args.SelectedItem is SearchSuggestion suggestion)
         {
-            ViewModel.Search.SelectSuggestion(suggestion);
+            _ignoreNextQuerySubmitted = true;
+            ViewModel.Search.OpenSuggestion(suggestion);
         }
     }
 

--- a/src/JellyBox/Models/CardFactory.cs
+++ b/src/JellyBox/Models/CardFactory.cs
@@ -68,7 +68,7 @@ internal sealed class CardFactory
             ImageWidth = imageWidth,
             ImageHeight = imageHeight,
             Image = image,
-            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item)),
+            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item.Id!.Value)),
             IsFavorite = item.UserData?.IsFavorite ?? false,
             IsPlayed = item.UserData?.Played ?? false,
             PlayedPercentage = item.UserData?.PlayedPercentage ?? 0,

--- a/src/JellyBox/Models/CardFactory.cs
+++ b/src/JellyBox/Models/CardFactory.cs
@@ -68,7 +68,9 @@ internal sealed class CardFactory
             ImageWidth = imageWidth,
             ImageHeight = imageHeight,
             Image = image,
-            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item.Id!.Value)),
+            NavigateCommand = item.Type == BaseItemDto_Type.CollectionFolder
+                ? new RelayCommand(() => _navigationManager.NavigateToItem(item))
+                : new RelayCommand(() => _navigationManager.NavigateToItem(item.Id!.Value)),
             IsFavorite = item.UserData?.IsFavorite ?? false,
             IsPlayed = item.UserData?.Played ?? false,
             PlayedPercentage = item.UserData?.PlayedPercentage ?? 0,

--- a/src/JellyBox/Models/SearchSuggestion.cs
+++ b/src/JellyBox/Models/SearchSuggestion.cs
@@ -1,0 +1,3 @@
+namespace JellyBox.Models;
+
+internal sealed record SearchSuggestion(string DisplayText, string? SecondaryText, Guid ItemId);

--- a/src/JellyBox/Package.appxmanifest
+++ b/src/JellyBox/Package.appxmanifest
@@ -21,7 +21,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.22000.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>
@@ -30,7 +30,7 @@
 
   <Applications>
     <Application Id="App"
-      Executable="$targetnametoken$.exe"
+      Executable="JellyBox.exe"
       EntryPoint="JellyBox.App">
       <uap:VisualElements
         DisplayName="JellyBox"

--- a/src/JellyBox/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/JellyBox/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Publish profile for Xbox / sideloaded Release packages.
+  Required because JellyBox uses Native AOT and must be self-contained on Xbox.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <UapAppxPackageBuildMode>StoreUpload</UapAppxPackageBuildMode>
+  </PropertyGroup>
+</Project>

--- a/src/JellyBox/Resources/Styles.xaml
+++ b/src/JellyBox/Resources/Styles.xaml
@@ -1011,11 +1011,7 @@
     <Style x:Key="SearchAutoSuggestBox" TargetType="AutoSuggestBox">
         <Setter Property="MinHeight" Value="48" />
         <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
-        <Setter Property="Background" Value="{StaticResource BackgroundElevated}" />
-        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtle}" />
-        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontSize" Value="{StaticResource FontM}" />
-        <Setter Property="Padding" Value="12,10" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualPrimaryBrush" Value="{StaticResource FocusBorder}" />
         <Setter Property="FocusVisualSecondaryBrush" Value="Transparent" />

--- a/src/JellyBox/Resources/Styles.xaml
+++ b/src/JellyBox/Resources/Styles.xaml
@@ -1008,6 +1008,20 @@
         </Setter>
     </Style>
 
+    <Style x:Key="SearchAutoSuggestBox" TargetType="AutoSuggestBox">
+        <Setter Property="MinHeight" Value="48" />
+        <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
+        <Setter Property="Background" Value="{StaticResource BackgroundElevated}" />
+        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtle}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FontSize" Value="{StaticResource FontM}" />
+        <Setter Property="Padding" Value="12,10" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="FocusVisualPrimaryBrush" Value="{StaticResource FocusBorder}" />
+        <Setter Property="FocusVisualSecondaryBrush" Value="Transparent" />
+        <Setter Property="FocusVisualPrimaryThickness" Value="3" />
+    </Style>
+
     <Style x:Key="PrimaryTextBox"  TargetType="TextBox">
         <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
         <Setter Property="MinHeight" Value="40" />

--- a/src/JellyBox/Resources/TransportControlsStyles.xaml
+++ b/src/JellyBox/Resources/TransportControlsStyles.xaml
@@ -115,7 +115,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Rewind"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RewindCommand}"
-                                                      ToolTipService.ToolTip="Rewind 10 seconds (LB)"
+                                                      ToolTipService.ToolTip="Rewind 10 seconds (LB / D-pad left)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon Glyph="&#xED3C;" FontFamily="Segoe MDL2 Assets" />
@@ -127,7 +127,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Play"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PlayPauseCommand}"
-                                                      ToolTipService.ToolTip="Play/Pause (Space)"
+                                                      ToolTipService.ToolTip="Play/Pause (A / Menu / Space)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon x:Name="CustomPlayPauseIcon" Glyph="&#xE768;" FontFamily="Segoe MDL2 Assets" />
@@ -139,7 +139,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Fast Forward"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FastForwardCommand}"
-                                                      ToolTipService.ToolTip="Fast forward 30 seconds (RB)"
+                                                      ToolTipService.ToolTip="Fast forward 30 seconds (RB / D-pad right)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon Glyph="&#xED3D;" FontFamily="Segoe MDL2 Assets" />
@@ -172,7 +172,7 @@
                                         <Button x:Name="CustomVolumeButton"
                                                 Style="{StaticResource TransportIconButtonStyle}"
                                                 Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ToggleMuteCommand}"
-                                                ToolTipService.ToolTip="Toggle mute (M)"
+                                                ToolTipService.ToolTip="Toggle mute (X / M)"
                                                 XYFocusKeyboardNavigation="Enabled">
                                             <FontIcon x:Name="CustomVolumeIcon" Glyph="&#xE767;" FontFamily="Segoe MDL2 Assets" />
                                             <Button.Flyout>

--- a/src/JellyBox/Services/CollectionNavigation.cs
+++ b/src/JellyBox/Services/CollectionNavigation.cs
@@ -1,0 +1,58 @@
+using JellyBox.Views;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.Services;
+
+internal static class CollectionNavigation
+{
+    internal static bool TryCreateLibraryParameters(BaseItemDto item, out Library.Parameters parameters)
+    {
+        parameters = default!;
+
+        if (item.Type != BaseItemDto_Type.CollectionFolder
+            || !item.Id.HasValue
+            || !TryMapCollectionType(item.CollectionType, out BaseItemKind itemKind))
+        {
+            return false;
+        }
+
+        parameters = new Library.Parameters(
+            item.Id.Value,
+            itemKind,
+            item.Name ?? GetDefaultTitle(item.CollectionType));
+
+        return true;
+    }
+
+    private static bool TryMapCollectionType(BaseItemDto_CollectionType? collectionType, out BaseItemKind itemKind)
+    {
+        itemKind = default;
+
+        switch (collectionType)
+        {
+            case BaseItemDto_CollectionType.Movies:
+                itemKind = BaseItemKind.Movie;
+                return true;
+            case BaseItemDto_CollectionType.Tvshows:
+                itemKind = BaseItemKind.Series;
+                return true;
+            case BaseItemDto_CollectionType.Boxsets:
+                itemKind = BaseItemKind.BoxSet;
+                return true;
+            case BaseItemDto_CollectionType.Books:
+                itemKind = BaseItemKind.Book;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static string GetDefaultTitle(BaseItemDto_CollectionType? collectionType) => collectionType switch
+    {
+        BaseItemDto_CollectionType.Movies => "Movies",
+        BaseItemDto_CollectionType.Tvshows => "TV Shows",
+        BaseItemDto_CollectionType.Boxsets => "Collections",
+        BaseItemDto_CollectionType.Books => "Books",
+        _ => "Library",
+    };
+}

--- a/src/JellyBox/Services/GamepadInput.cs
+++ b/src/JellyBox/Services/GamepadInput.cs
@@ -10,7 +10,7 @@ namespace JellyBox.Services;
 internal static class GamepadInput
 {
     public static bool IsTextInputFocused()
-        => FocusManager.GetFocusedElement() is TextBox or PasswordBox;
+        => FocusManager.GetFocusedElement() is TextBox or PasswordBox or AutoSuggestBox;
 
     public static bool IsAcceptKey(VirtualKey key)
         => key is VirtualKey.Enter or VirtualKey.GamepadA or VirtualKey.Space;

--- a/src/JellyBox/Services/GamepadInput.cs
+++ b/src/JellyBox/Services/GamepadInput.cs
@@ -1,0 +1,55 @@
+using Windows.System;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace JellyBox.Services;
+
+/// <summary>
+/// Shared Xbox / gamepad virtual-key helpers for consistent controller input across the app.
+/// </summary>
+internal static class GamepadInput
+{
+    public static bool IsTextInputFocused()
+        => FocusManager.GetFocusedElement() is TextBox or PasswordBox;
+
+    public static bool IsAcceptKey(VirtualKey key)
+        => key is VirtualKey.Enter or VirtualKey.GamepadA or VirtualKey.Space;
+
+    public static bool IsBackKey(VirtualKey key)
+        => key is VirtualKey.Back or VirtualKey.Escape or VirtualKey.GamepadB or VirtualKey.GoBack;
+
+    public static bool IsMenuToggleKey(VirtualKey key)
+        => key is VirtualKey.GamepadMenu or VirtualKey.GamepadView or VirtualKey.M;
+
+    public static bool IsNavigateLeftKey(VirtualKey key)
+        => key is VirtualKey.Left
+            or VirtualKey.GamepadDPadLeft
+            or VirtualKey.GamepadLeftThumbstickLeft
+            or VirtualKey.NavigationLeft;
+
+    public static bool IsNavigateRightKey(VirtualKey key)
+        => key is VirtualKey.Right
+            or VirtualKey.GamepadDPadRight
+            or VirtualKey.GamepadLeftThumbstickRight
+            or VirtualKey.NavigationRight;
+
+    public static bool IsVolumeUpKey(VirtualKey key)
+        => key is VirtualKey.Up
+            or VirtualKey.GamepadDPadUp
+            or VirtualKey.GamepadLeftThumbstickUp;
+
+    public static bool IsVolumeDownKey(VirtualKey key)
+        => key is VirtualKey.Down
+            or VirtualKey.GamepadDPadDown
+            or VirtualKey.GamepadLeftThumbstickDown;
+
+    public static bool IsSeekBackwardKey(VirtualKey key)
+        => key is VirtualKey.Left
+            or VirtualKey.GamepadDPadLeft
+            or VirtualKey.GamepadLeftThumbstickLeft;
+
+    public static bool IsSeekForwardKey(VirtualKey key)
+        => key is VirtualKey.Right
+            or VirtualKey.GamepadDPadRight
+            or VirtualKey.GamepadLeftThumbstickRight;
+}

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -114,31 +114,16 @@ internal sealed class NavigationManager
     public void NavigateToItem(BaseItemDto item)
     {
         Guid itemId = item.Id!.Value;
-        if (item.Type == BaseItemDto_Type.CollectionFolder)
-        {
-            switch (item.CollectionType)
-            {
-                case BaseItemDto_CollectionType.Movies:
-                {
-                    CurrentItem = itemId;
-                    NavigateContentFrame<Library>(new Library.Parameters(itemId, BaseItemKind.Movie, item.Name ?? "Movies"));
-                    return;
-                }
-                case BaseItemDto_CollectionType.Tvshows:
-                {
-                    CurrentItem = itemId;
-                    NavigateContentFrame<Library>(new Library.Parameters(itemId, BaseItemKind.Series, item.Name ?? "TV Shows"));
-                    return;
-                }
-            }
 
-            // TODO: Some kind of error message. Or genericize the collection view.
-        }
-        else
+        if (CollectionNavigation.TryCreateLibraryParameters(item, out Library.Parameters libraryParameters))
         {
             CurrentItem = itemId;
-            NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
+            NavigateContentFrame<Library>(libraryParameters);
+            return;
         }
+
+        CurrentItem = itemId;
+        NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
     }
 
     public void NavigateToPerson(BaseItemPerson person)

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -18,6 +18,21 @@ internal sealed class NavigationManager
 
     public event Action? MenuOpenRequested;
 
+    /// <summary>
+    /// Opens the shell navigation menu.
+    /// </summary>
+    public Action? OpenNavigationMenu { get; set; }
+
+    /// <summary>
+    /// Toggles the shell navigation menu.
+    /// </summary>
+    public Action? ToggleNavigationMenu { get; set; }
+
+    /// <summary>
+    /// Closes the shell navigation menu when open. Returns true if the menu was closed.
+    /// </summary>
+    public Func<bool>? TryCloseNavigationMenu { get; set; }
+
     private Frame _appFrame = null!; // TODO
 
     private Frame? _contentFrame;
@@ -45,6 +60,7 @@ internal sealed class NavigationManager
 
         SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
         Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += AcceleratorKeyActivated;
+        Window.Current.CoreWindow.KeyDown += CoreWindowKeyDown;
         Window.Current.CoreWindow.PointerPressed += PointerPressed;
     }
 
@@ -250,9 +266,18 @@ internal sealed class NavigationManager
         bool onlyAlt = menuKey && !controlKey && !shiftKey;
         VirtualKey virtualKey = e.VirtualKey;
 
-        if ((virtualKey is VirtualKey.GoBack && noModifiers)
-            || (virtualKey is VirtualKey.Left && onlyAlt)
-            || (virtualKey is VirtualKey.Back && noModifiers))
+        if (GamepadInput.IsBackKey(virtualKey) && noModifiers)
+        {
+            if (TryCloseNavigationMenu?.Invoke() == true)
+            {
+                e.Handled = true;
+            }
+            else
+            {
+                e.Handled = GoBack();
+            }
+        }
+        else if (virtualKey is VirtualKey.Left && onlyAlt)
         {
             e.Handled = GoBack();
         }
@@ -260,6 +285,51 @@ internal sealed class NavigationManager
             || (virtualKey is VirtualKey.Right && onlyAlt))
         {
             e.Handled = GoForward();
+        }
+    }
+
+    /// <summary>
+    /// Global gamepad and keyboard shortcuts for the main app shell (home, library, details).
+    /// Full-screen pages such as video playback register their own handlers.
+    /// </summary>
+    private void CoreWindowKeyDown(CoreWindow sender, KeyEventArgs e)
+    {
+        if (_contentFrame is null || GamepadInput.IsTextInputFocused())
+        {
+            return;
+        }
+
+        VirtualKey key = e.VirtualKey;
+
+        if (GamepadInput.IsMenuToggleKey(key))
+        {
+            ToggleNavigationMenu?.Invoke();
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsBackKey(key) && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (key is VirtualKey.Escape && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsNavigateRightKey(key) && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsNavigateLeftKey(key) && !FocusManager.TryMoveFocus(FocusNavigationDirection.Left))
+        {
+            OpenNavigationMenu?.Invoke();
+            e.Handled = true;
         }
     }
 

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -16,6 +16,9 @@ internal sealed class NavigationManager
     // Fake item id used to identify the home page
     public static readonly Guid HomeId = new Guid("CDF95D47-90C2-4057-B12C-BA81C34F2CB9");
 
+    // Fake item id used to identify the search page
+    public static readonly Guid SearchId = new Guid("A4B8C2E1-6F3D-4A91-9B7E-2D5C8F1A3E64");
+
     public event Action? MenuOpenRequested;
 
     /// <summary>
@@ -94,6 +97,18 @@ internal sealed class NavigationManager
     {
         CurrentItem = HomeId;
         NavigateContentFrame<Home>();
+    }
+
+    public void NavigateToSearch(string query)
+    {
+        CurrentItem = SearchId;
+        NavigateContentFrame<Search>(new Search.Parameters(query));
+    }
+
+    public void NavigateToItem(Guid itemId)
+    {
+        CurrentItem = itemId;
+        NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
     }
 
     public void NavigateToItem(BaseItemDto item)

--- a/src/JellyBox/Services/ShellFocusCoordinator.cs
+++ b/src/JellyBox/Services/ShellFocusCoordinator.cs
@@ -1,0 +1,47 @@
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace JellyBox.Services;
+
+/// <summary>
+/// Coordinates focus between the shell search bar and content pages.
+/// Search is only focused when the user explicitly navigates up to the top edge.
+/// </summary>
+#pragma warning disable CA1812 // Instantiated via dependency injection.
+internal sealed class ShellFocusCoordinator
+#pragma warning restore CA1812
+{
+    private AutoSuggestBox? _searchBox;
+
+    public void RegisterSearchBox(AutoSuggestBox searchBox) => _searchBox = searchBox;
+
+    public void OnContentNavigated()
+    {
+        if (_searchBox is null)
+        {
+            return;
+        }
+
+        // FocusState.Unfocused is invalid for Control.Focus and throws on Xbox.
+        _searchBox.IsTabStop = false;
+    }
+
+    public bool TryFocusSearch()
+    {
+        if (_searchBox is null)
+        {
+            return false;
+        }
+
+        _searchBox.IsTabStop = true;
+        return _searchBox.Focus(FocusState.Programmatic);
+    }
+
+    public void OnSearchDismissed()
+    {
+        if (_searchBox is not null)
+        {
+            _searchBox.IsTabStop = false;
+        }
+    }
+}

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -144,9 +144,12 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         _cardFactory = cardFactory;
     }
 
+    public void CancelLoading() => Interlocked.Increment(ref _loadVersion);
+
     internal async void HandleParameters(ItemDetails.Parameters parameters)
     {
         int version = Interlocked.Increment(ref _loadVersion);
+        ResetDisplayState();
 
         try
         {
@@ -213,12 +216,20 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
             if (Item.MediaSources is not null && Item.MediaSources.Count > 0)
             {
-                SourceContainers = new ObservableCollection<MediaSourceInfoWrapper>(Item.MediaSources.Select(s => new MediaSourceInfoWrapper(s.Name!, s)));
+                SourceContainers = new ObservableCollection<MediaSourceInfoWrapper>(
+                    Item.MediaSources.Select(s => new MediaSourceInfoWrapper(s.Name ?? "Unknown", s)));
                 HasMultipleSources = SourceContainers.Count > 1;
                 HasSingleSource = SourceContainers.Count == 1;
 
                 // This will trigger OnSelectedSourceContainerChanged, which populates the video, audio, and subtitle drop-downs.
                 SelectedSourceContainer = SourceContainers[0];
+            }
+            else
+            {
+                SourceContainers = null;
+                HasMultipleSources = false;
+                HasSingleSource = false;
+                SelectedSourceContainer = null;
             }
 
             TagLine = Item.Taglines is not null && Item.Taglines.Count > 0 ? Item.Taglines[0] : null;
@@ -267,17 +278,52 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     partial void OnSelectedSourceContainerChanged(MediaSourceInfoWrapper? value)
     {
-        if (value is not null)
+        if (value is null)
+        {
+            return;
+        }
+
+        try
         {
             DetermineVideoOptions(value.Value);
             DetermineAudioOptions(value.Value);
             DetermineSubtitleOptions(value.Value);
         }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error in OnSelectedSourceContainerChanged: {ex}");
+        }
+    }
+
+    private void ResetDisplayState()
+    {
+        SourceContainers = null;
+        HasMultipleSources = false;
+        HasSingleSource = false;
+        SelectedSourceContainer = null;
+        VideoStreams = null;
+        SelectedVideoStream = null;
+        AudioStreams = null;
+        SelectedAudioStream = null;
+        HasMultipleAudioStreams = false;
+        HasSingleAudioStream = false;
+        SubtitleStreams = null;
+        SelectedSubtitleStream = null;
+        HasMultipleSubtitleStreams = false;
+        HasSingleSubtitleStream = false;
+        Sections = null;
     }
 
     private void DetermineVideoOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> videoStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            VideoStreams = [];
+            SelectedVideoStream = null;
+            return;
+        }
+
+        List<MediaStream> videoStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Video)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -309,7 +355,16 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     private void DetermineAudioOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> audioStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            AudioStreams = [];
+            HasMultipleAudioStreams = false;
+            HasSingleAudioStream = false;
+            SelectedAudioStream = null;
+            return;
+        }
+
+        List<MediaStream> audioStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Audio)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -337,7 +392,16 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     private void DetermineSubtitleOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> subtitleStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            SubtitleStreams = [MediaStreamOption.SubtitlesOff];
+            HasMultipleSubtitleStreams = false;
+            HasSingleSubtitleStream = true;
+            SelectedSubtitleStream = MediaStreamOption.SubtitlesOff;
+            return;
+        }
+
+        List<MediaStream> subtitleStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Subtitle)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -28,6 +28,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
     private readonly JellyfinImageResolver _imageResolver;
     private readonly NavigationManager _navigationManager;
     private readonly CardFactory _cardFactory;
+    private int _loadVersion;
 
     [ObservableProperty]
     public partial BaseItemDto? Item { get; set; }
@@ -145,11 +146,24 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     internal async void HandleParameters(ItemDetails.Parameters parameters)
     {
+        int version = Interlocked.Increment(ref _loadVersion);
+
         try
         {
-            Item = await _jellyfinApiClient.Items[parameters.ItemId].GetAsync();
+            BaseItemDto? item = await _jellyfinApiClient.Items[parameters.ItemId].GetAsync();
+            if (version != _loadVersion)
+            {
+                return;
+            }
 
-            Name = Item!.Name;
+            if (item is null)
+            {
+                return;
+            }
+
+            Item = item;
+
+            Name = Item.Name;
 
             // Disable backdrop for Person and Book types because they only have primary images
             if (Item.Type is not BaseItemDto_Type.Person and not BaseItemDto_Type.Book)
@@ -232,6 +246,11 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             foreach (Task<Section?> sectionTask in sectionTasks)
             {
                 Section? section = await sectionTask;
+                if (version != _loadVersion)
+                {
+                    return;
+                }
+
                 if (section is not null)
                 {
                     sections.Add(section);
@@ -511,7 +530,18 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             return;
         }
 
-        IsPlayed = Item.UserData!.Played.GetValueOrDefault();
+        if (Item.UserData is null)
+        {
+            IsPlayed = false;
+            IsFavorite = false;
+            CanResume = false;
+            PlayButtonText = "Play";
+            PlayButtonGlyph = Glyphs.Play;
+            ResumePositionText = null;
+            return;
+        }
+
+        IsPlayed = Item.UserData.Played.GetValueOrDefault();
         IsFavorite = Item.UserData.IsFavorite.GetValueOrDefault();
 
         long positionTicks = Item.UserData.PlaybackPositionTicks.GetValueOrDefault();

--- a/src/JellyBox/ViewModels/MainPageViewModel.cs
+++ b/src/JellyBox/ViewModels/MainPageViewModel.cs
@@ -26,14 +26,18 @@ internal sealed partial class MainPageViewModel : ObservableObject
     [ObservableProperty]
     public partial ObservableCollection<NavigationViewItemBase>? NavigationItems { get; set; }
 
+    public ShellSearchViewModel Search { get; }
+
     public MainPageViewModel(
         AppSettings appSettings,
         JellyfinApiClient jellyfinApiClient,
-        NavigationManager navigationManager)
+        NavigationManager navigationManager,
+        ShellSearchViewModel shellSearchViewModel)
     {
         _appSettings = appSettings;
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
+        Search = shellSearchViewModel;
         _navigationManager.MenuOpenRequested += () => IsMenuOpen = true;
         _navigationManager.OpenNavigationMenu = () => IsMenuOpen = true;
         _navigationManager.ToggleNavigationMenu = () => IsMenuOpen = !IsMenuOpen;

--- a/src/JellyBox/ViewModels/MainPageViewModel.cs
+++ b/src/JellyBox/ViewModels/MainPageViewModel.cs
@@ -35,6 +35,18 @@ internal sealed partial class MainPageViewModel : ObservableObject
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
         _navigationManager.MenuOpenRequested += () => IsMenuOpen = true;
+        _navigationManager.OpenNavigationMenu = () => IsMenuOpen = true;
+        _navigationManager.ToggleNavigationMenu = () => IsMenuOpen = !IsMenuOpen;
+        _navigationManager.TryCloseNavigationMenu = () =>
+        {
+            if (!IsMenuOpen)
+            {
+                return false;
+            }
+
+            IsMenuOpen = false;
+            return true;
+        };
     }
 
     [RelayCommand]

--- a/src/JellyBox/ViewModels/SearchViewModel.cs
+++ b/src/JellyBox/ViewModels/SearchViewModel.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Views;
+using Jellyfin.Sdk;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.ViewModels;
+
+#pragma warning disable CA1812
+internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewModel
+#pragma warning restore CA1812
+{
+    private const int ResultLimit = 100;
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly CardFactory _cardFactory;
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial string Query { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string ResultsTitle { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string? ResultsSubtitle { get; private set; }
+
+    [ObservableProperty]
+    public partial bool ShowEmptyState { get; private set; }
+
+    [ObservableProperty]
+    public partial IReadOnlyList<Card>? Items { get; private set; }
+
+    public SearchViewModel(
+        JellyfinApiClient jellyfinApiClient,
+        CardFactory cardFactory)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+        _cardFactory = cardFactory;
+    }
+
+    public void HandleParameters(Search.Parameters parameters)
+    {
+        Query = parameters.Query.Trim();
+        ResultsTitle = $"Results for \"{Query}\"";
+        Items = null;
+        ShowEmptyState = false;
+        ResultsSubtitle = null;
+        _ = LoadResultsAsync();
+    }
+
+    private async Task LoadResultsAsync()
+    {
+        IsLoading = true;
+
+        try
+        {
+            BaseItemDtoQueryResult? result = await _jellyfinApiClient.Items.GetAsync(parameters =>
+            {
+                parameters.QueryParameters.SearchTerm = Query;
+                parameters.QueryParameters.IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series];
+                parameters.QueryParameters.Recursive = true;
+                parameters.QueryParameters.SortBy = [ItemSortBy.SortName];
+                parameters.QueryParameters.Limit = ResultLimit;
+                parameters.QueryParameters.Fields = [ItemFields.PrimaryImageAspectRatio, ItemFields.MediaSourceCount];
+                parameters.QueryParameters.ImageTypeLimit = 1;
+                parameters.QueryParameters.EnableImageTypes = [ImageType.Primary, ImageType.Backdrop, ImageType.Banner, ImageType.Thumb];
+            });
+
+            if (result?.Items is null || result.Items.Count == 0)
+            {
+                Items = [];
+                ShowEmptyState = true;
+                ResultsSubtitle = "No movies or TV shows matched your search.";
+                return;
+            }
+
+            List<Card> items = new(result.Items.Count);
+            foreach (BaseItemDto item in result.Items)
+            {
+                if (!item.Id.HasValue)
+                {
+                    continue;
+                }
+
+                if (item.Type is not (BaseItemDto_Type.Movie or BaseItemDto_Type.Series))
+                {
+                    continue;
+                }
+
+                items.Add(_cardFactory.CreateFromItem(item, CardShape.Portrait, preferredImageType: null));
+            }
+
+            Items = items;
+            ShowEmptyState = items.Count == 0;
+            ResultsSubtitle = items.Count == 0
+                ? "No movies or TV shows matched your search."
+                : items.Count == 1
+                    ? "1 result"
+                    : $"{items.Count} results";
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in SearchViewModel.LoadResultsAsync: {ex}");
+            Items = [];
+            ShowEmptyState = true;
+            ResultsSubtitle = "Something went wrong while searching. Please try again.";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+}

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -47,8 +47,15 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         _navigationManager.NavigateToSearch(trimmed);
     }
 
-    public void SelectSuggestion(SearchSuggestion suggestion)
-        => _navigationManager.NavigateToItem(suggestion.ItemId);
+    public void OpenSuggestion(SearchSuggestion suggestion)
+    {
+        Interlocked.Increment(ref _searchVersion);
+        ClearSuggestions();
+        Query = suggestion.DisplayText;
+        _navigationManager.NavigateToItem(suggestion.ItemId);
+    }
+
+    public void ClearSuggestions() => ReplaceSuggestions([]);
 
     private async Task UpdateSuggestionsAsync(string query)
     {

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Services;
+using Jellyfin.Sdk;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.ViewModels;
+
+#pragma warning disable CA1812
+internal sealed partial class ShellSearchViewModel : ObservableObject
+#pragma warning restore CA1812
+{
+    private const int MinimumQueryLength = 2;
+    private const int SuggestionLimit = 8;
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(350);
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly NavigationManager _navigationManager;
+    private int _searchVersion;
+
+    [ObservableProperty]
+    public partial string Query { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial IReadOnlyList<SearchSuggestion> Suggestions { get; set; } = [];
+
+    public ShellSearchViewModel(
+        JellyfinApiClient jellyfinApiClient,
+        NavigationManager navigationManager)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+        _navigationManager = navigationManager;
+    }
+
+    partial void OnQueryChanged(string value) => _ = UpdateSuggestionsAsync(value);
+
+    public void SubmitQuery(string? query)
+    {
+        string trimmed = (query ?? Query).Trim();
+        if (trimmed.Length < MinimumQueryLength)
+        {
+            return;
+        }
+
+        Query = trimmed;
+        _navigationManager.NavigateToSearch(trimmed);
+    }
+
+    public void SelectSuggestion(SearchSuggestion suggestion)
+        => _navigationManager.NavigateToItem(suggestion.ItemId);
+
+    private async Task UpdateSuggestionsAsync(string query)
+    {
+        int version = Interlocked.Increment(ref _searchVersion);
+
+        string trimmed = query.Trim();
+        if (trimmed.Length < MinimumQueryLength)
+        {
+            Suggestions = [];
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(DebounceDelay);
+
+            if (version != _searchVersion)
+            {
+                return;
+            }
+
+            SearchHintResult? result = await _jellyfinApiClient.Search.Hints.GetAsync(
+                parameters =>
+                {
+                    parameters.QueryParameters.SearchTerm = trimmed;
+                    parameters.QueryParameters.IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series];
+                    parameters.QueryParameters.IncludeMedia = true;
+                    parameters.QueryParameters.Limit = SuggestionLimit;
+                });
+
+            if (version != _searchVersion)
+            {
+                return;
+            }
+
+            if (result?.SearchHints is null)
+            {
+                Suggestions = [];
+                return;
+            }
+
+            List<SearchSuggestion> suggestions = new(result.SearchHints.Count);
+            foreach (SearchHint hint in result.SearchHints)
+            {
+                SearchSuggestion? suggestion = CreateSuggestion(hint);
+                if (suggestion is not null)
+                {
+                    suggestions.Add(suggestion);
+                }
+            }
+
+            Suggestions = suggestions;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in ShellSearchViewModel.UpdateSuggestionsAsync: {ex}");
+            Suggestions = [];
+        }
+    }
+
+    private static SearchSuggestion? CreateSuggestion(SearchHint hint)
+    {
+        if (hint.Type is not (SearchHint_Type.Movie or SearchHint_Type.Series))
+        {
+            return null;
+        }
+
+        if (!hint.Id.HasValue || string.IsNullOrWhiteSpace(hint.Name))
+        {
+            return null;
+        }
+
+        string typeLabel = hint.Type == SearchHint_Type.Movie ? "Movie" : "TV Show";
+        string? secondaryText = hint.ProductionYear.HasValue
+            ? $"{typeLabel} · {hint.ProductionYear.Value}"
+            : typeLabel;
+
+        return new SearchSuggestion(hint.Name, secondaryText, hint.Id.Value);
+    }
+}

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -47,13 +47,13 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         _navigationManager.NavigateToSearch(trimmed);
     }
 
-    public void OpenSuggestion(SearchSuggestion suggestion)
-    {
-        Interlocked.Increment(ref _searchVersion);
-        ClearSuggestions();
-        Query = suggestion.DisplayText;
-        _navigationManager.NavigateToItem(suggestion.ItemId);
-    }
+    public void PrepareSuggestionNavigation()
+        => Interlocked.Increment(ref _searchVersion);
+
+    public void SetQueryText(string query) => Query = query;
+
+    public void NavigateToItem(Guid itemId)
+        => _navigationManager.NavigateToItem(itemId);
 
     public void ClearSuggestions() => ReplaceSuggestions([]);
 

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using JellyBox.Models;
@@ -22,8 +23,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
     [ObservableProperty]
     public partial string Query { get; set; } = string.Empty;
 
-    [ObservableProperty]
-    public partial IReadOnlyList<SearchSuggestion> Suggestions { get; set; } = [];
+    public ObservableCollection<SearchSuggestion> Suggestions { get; } = [];
 
     public ShellSearchViewModel(
         JellyfinApiClient jellyfinApiClient,
@@ -57,7 +57,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         string trimmed = query.Trim();
         if (trimmed.Length < MinimumQueryLength)
         {
-            Suggestions = [];
+            ReplaceSuggestions([]);
             return;
         }
 
@@ -86,7 +86,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
 
             if (result?.SearchHints is null)
             {
-                Suggestions = [];
+                ReplaceSuggestions([]);
                 return;
             }
 
@@ -100,12 +100,21 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
                 }
             }
 
-            Suggestions = suggestions;
+            ReplaceSuggestions(suggestions);
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"Error in ShellSearchViewModel.UpdateSuggestionsAsync: {ex}");
-            Suggestions = [];
+            ReplaceSuggestions([]);
+        }
+    }
+
+    private void ReplaceSuggestions(IEnumerable<SearchSuggestion> suggestions)
+    {
+        Suggestions.Clear();
+        foreach (SearchSuggestion suggestion in suggestions)
+        {
+            Suggestions.Add(suggestion);
         }
     }
 

--- a/src/JellyBox/ViewModels/VideoViewModel.MediaSource.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.MediaSource.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
+using System.Net.Http;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Kiota.Abstractions;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Media.Streaming.Adaptive;
 using Windows.Security.ExchangeActiveSyncProvisioning;
+using Windows.Storage.Streams;
 
 namespace JellyBox.ViewModels;
 
@@ -12,6 +15,43 @@ namespace JellyBox.ViewModels;
 internal sealed partial class VideoViewModel
 #pragma warning restore CA1812
 {
+    /// <summary>
+    /// Fetches playback info, preferring direct play when subtitles can be rendered client-side.
+    /// </summary>
+    private async Task<(MediaSourceInfo? MediaSource, string? PlaySessionId)> GetPlaybackInfoForPlaybackAsync(
+        Guid itemId,
+        string? mediaSourceId,
+        int? audioStreamIndex,
+        int? subtitleStreamIndex,
+        long? startTimeTicks)
+    {
+        if (subtitleStreamIndex is >= 0)
+        {
+            (MediaSourceInfo? mediaSource, string? playSessionId) = await GetPlaybackInfoAsync(
+                itemId,
+                mediaSourceId,
+                audioStreamIndex,
+                subtitleStreamIndex: null,
+                startTimeTicks);
+
+            if (mediaSource is not null
+                && CanRenderSubtitleClientSide(mediaSource, subtitleStreamIndex.Value)
+                && (mediaSource.SupportsDirectPlay.GetValueOrDefault() || mediaSource.SupportsDirectStream.GetValueOrDefault()))
+            {
+                Debug.WriteLine(
+                    $"Using client-side subtitles (Jellyfin index {subtitleStreamIndex.Value}); omitting subtitle index from playback request to avoid remux/transcode.");
+                return (mediaSource, playSessionId);
+            }
+        }
+
+        return await GetPlaybackInfoAsync(
+            itemId,
+            mediaSourceId,
+            audioStreamIndex,
+            subtitleStreamIndex,
+            startTimeTicks);
+    }
+
     /// <summary>
     /// Fetches playback info from the Jellyfin API.
     /// </summary>
@@ -45,6 +85,14 @@ internal sealed partial class VideoViewModel
         }
 
         return (response.MediaSources[0], response.PlaySessionId);
+    }
+
+    private static bool CanRenderSubtitleClientSide(MediaSourceInfo mediaSource, int subtitleStreamIndex)
+    {
+        MediaStream? stream = mediaSource.MediaStreams?
+            .FirstOrDefault(s => s.Type == MediaStream_Type.Subtitle && s.Index == subtitleStreamIndex);
+
+        return stream is not null && IsSubtitleFormatSupported(stream);
     }
 
     /// <summary>
@@ -99,8 +147,8 @@ internal sealed partial class VideoViewModel
 
         MediaSource mediaSource = await CreateMediaSourceAsync(mediaUri, isAdaptive);
 
-        // Add all external subtitles upfront for seamless switching
-        AddAllExternalSubtitles(mediaSource, mediaSourceInfo);
+        // Only load the selected external subtitle. Loading every track upfront causes extra network I/O and parsing.
+        await AddSelectedExternalSubtitleAsync(mediaSource, mediaSourceInfo);
 
         MediaPlaybackItem? playbackItem = new(mediaSource, startPosition);
 
@@ -117,49 +165,85 @@ internal sealed partial class VideoViewModel
     }
 
     /// <summary>
-    /// Adds all external subtitles in supported formats to the media source for seamless switching.
+    /// Adds the selected external subtitle in a supported format.
     /// UWP TimedTextSource only supports SRT (subrip) and VTT formats.
-    /// External subtitles are added in the same order as they appear in MediaStreams.
     /// </summary>
-    private void AddAllExternalSubtitles(MediaSource mediaSource, MediaSourceInfo mediaSourceInfo)
+    private async Task AddSelectedExternalSubtitleAsync(MediaSource mediaSource, MediaSourceInfo mediaSourceInfo)
     {
         if (mediaSourceInfo.MediaStreams is null)
         {
             return;
         }
 
-        foreach (MediaStream subtitleTrack in mediaSourceInfo.MediaStreams
-            .Where(s => s.Type == MediaStream_Type.Subtitle && s.IsExternal.GetValueOrDefault()))
+        int? selectedSubtitleIndex = _playbackProgressInfo?.SubtitleStreamIndex;
+        if (selectedSubtitleIndex is not >= 0)
         {
-            if (!IsSubtitleFormatSupported(subtitleTrack))
-            {
-                Debug.WriteLine($"Skipping unsupported external subtitle format: {subtitleTrack.Codec} (index {subtitleTrack.Index})");
-                continue;
-            }
-
-            string? subtitleUrl = subtitleTrack.DeliveryUrl;
-            if (string.IsNullOrEmpty(subtitleUrl))
-            {
-                Debug.WriteLine($"Subtitle track {subtitleTrack.Index} has no delivery URL.");
-                continue;
-            }
-
-            if (!subtitleTrack.IsExternalUrl.GetValueOrDefault())
-            {
-                subtitleUrl = _sdkClientSettings.ServerUrl + subtitleUrl;
-            }
-
-            if (Uri.TryCreate(subtitleUrl, UriKind.Absolute, out Uri? subtitleUri))
-            {
-                TimedTextSource timedTextSource = TimedTextSource.CreateFromUri(subtitleUri);
-                mediaSource.ExternalTimedTextSources.Add(timedTextSource);
-                Debug.WriteLine($"Added external subtitle (index {subtitleTrack.Index}): {subtitleUri}");
-            }
-            else
-            {
-                Debug.WriteLine($"Failed to parse subtitle URL: {subtitleUrl}");
-            }
+            return;
         }
+
+        MediaStream? subtitleTrack = mediaSourceInfo.MediaStreams
+            .FirstOrDefault(s => s.Type == MediaStream_Type.Subtitle
+                && s.IsExternal.GetValueOrDefault()
+                && s.Index == selectedSubtitleIndex);
+
+        if (subtitleTrack is null)
+        {
+            return;
+        }
+
+        if (!IsSubtitleFormatSupported(subtitleTrack))
+        {
+            Debug.WriteLine($"Skipping unsupported external subtitle format: {subtitleTrack.Codec} (index {subtitleTrack.Index})");
+            return;
+        }
+
+        string? subtitleUrl = subtitleTrack.DeliveryUrl;
+        if (string.IsNullOrEmpty(subtitleUrl))
+        {
+            Debug.WriteLine($"Subtitle track {subtitleTrack.Index} has no delivery URL.");
+            return;
+        }
+
+        Uri subtitleUri = BuildAuthenticatedSubtitleUri(subtitleUrl, subtitleTrack.IsExternalUrl.GetValueOrDefault());
+
+        try
+        {
+            HttpClient client = _httpClientFactory.CreateClient("Jellyfin");
+            using HttpResponseMessage response = await client.GetAsync(subtitleUri);
+            response.EnsureSuccessStatusCode();
+
+            byte[] bytes = await response.Content.ReadAsByteArrayAsync();
+#pragma warning disable CA2000 // MediaSource owns the stream for the lifetime of playback.
+            InMemoryRandomAccessStream stream = new();
+#pragma warning restore CA2000
+            await stream.WriteAsync(bytes.AsBuffer());
+            stream.Seek(0);
+
+            TimedTextSource timedTextSource = TimedTextSource.CreateFromStream(stream, subtitleTrack.Language ?? string.Empty);
+            mediaSource.ExternalTimedTextSources.Add(timedTextSource);
+            Debug.WriteLine($"Added external subtitle from stream (index {subtitleTrack.Index}): {subtitleUri}");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to download subtitle stream, falling back to URI: {ex.Message}");
+            TimedTextSource timedTextSource = TimedTextSource.CreateFromUri(subtitleUri);
+            mediaSource.ExternalTimedTextSources.Add(timedTextSource);
+        }
+    }
+
+    private Uri BuildAuthenticatedSubtitleUri(string subtitleUrl, bool isExternalUrl)
+    {
+        string url = isExternalUrl ? subtitleUrl : _sdkClientSettings.ServerUrl + subtitleUrl;
+        Uri uri = new(url);
+
+        if (string.IsNullOrEmpty(_sdkClientSettings.AccessToken)
+            || uri.Query.Contains("api_key=", StringComparison.OrdinalIgnoreCase))
+        {
+            return uri;
+        }
+
+        string separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&";
+        return new Uri($"{uri.AbsoluteUri}{separator}api_key={_sdkClientSettings.AccessToken}");
     }
 
     private Uri? BuildMediaUri(MediaSourceInfo mediaSourceInfo)
@@ -199,6 +283,11 @@ internal sealed partial class VideoViewModel
 
     private async Task<int> DetectBitrateAsync()
     {
+        if (_cachedMaxStreamingBitrate.HasValue)
+        {
+            return _cachedMaxStreamingBitrate.Value;
+        }
+
         const int BitrateTestSize = 1024 * 1024; // 1MB
         const int DownloadChunkSize = 64 * 1024; // 64KB
         const double SafetyRatio = 0.8; // Only allow 80% of the detected bitrate to avoid buffering.
@@ -236,6 +325,7 @@ internal sealed partial class VideoViewModel
         double bytesPerSecond = totalBytesRead / responseTimeSeconds;
         int bitrate = (int)Math.Round(bytesPerSecond * 8 * SafetyRatio);
         Debug.WriteLine($"Downloaded {totalBytesRead} bytes in {responseTimeSeconds:F2}s. Using max bitrate of {bitrate}");
+        _cachedMaxStreamingBitrate = bitrate;
         return bitrate;
     }
 }

--- a/src/JellyBox/ViewModels/VideoViewModel.Playback.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Playback.cs
@@ -21,6 +21,7 @@ internal sealed partial class VideoViewModel
         {
             _transportControls = transportControls;
             _currentItem = parameters.Item;
+            _cachedMaxStreamingBitrate = null;
             BaseItemDto item = _currentItem;
             _playerElement = playerElement;
 
@@ -223,7 +224,7 @@ internal sealed partial class VideoViewModel
         }
 
         // Get playback info with current track selections
-        (MediaSourceInfo? mediaSourceInfo, string? playSessionId) = await GetPlaybackInfoAsync(
+        (MediaSourceInfo? mediaSourceInfo, string? playSessionId) = await GetPlaybackInfoForPlaybackAsync(
             _currentItem.Id!.Value,
             mediaSourceId,
             _playbackProgressInfo.AudioStreamIndex,

--- a/src/JellyBox/ViewModels/VideoViewModel.Tracks.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Tracks.cs
@@ -90,11 +90,16 @@ internal sealed partial class VideoViewModel
 
     private void OnTimedMetadataTracksChanged(MediaPlaybackItem sender, IVectorChangedEventArgs args)
     {
+        if (args.CollectionChange != CollectionChange.ItemInserted)
+        {
+            return;
+        }
+
         // Capture the sender reference for use in the dispatcher callback
         MediaPlaybackItem playbackItem = sender;
 
         _ = CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
-            CoreDispatcherPriority.Normal,
+            CoreDispatcherPriority.Low,
             () =>
             {
                 try
@@ -105,19 +110,41 @@ internal sealed partial class VideoViewModel
                         return;
                     }
 
-                    // Present the selected subtitle track if one is selected
-                    int selectedIndex = _playbackProgressInfo?.SubtitleStreamIndex ?? -1;
-                    int? uwpIndex = GetSubtitleUwpIndex(selectedIndex);
-                    if (uwpIndex.HasValue && uwpIndex.Value < playbackItem.TimedMetadataTracks.Count)
-                    {
-                        playbackItem.TimedMetadataTracks.SetPresentationMode((uint)uwpIndex.Value, TimedMetadataTrackPresentationMode.PlatformPresented);
-                    }
+                    PresentSelectedSubtitleTrack(playbackItem);
                 }
                 catch (Exception ex)
                 {
                     Debug.WriteLine($"Error in OnTimedMetadataTracksChanged: {ex}");
                 }
             });
+    }
+
+    private void PresentSelectedSubtitleTrack(MediaPlaybackItem playbackItem)
+    {
+        int selectedIndex = _playbackProgressInfo?.SubtitleStreamIndex ?? -1;
+        if (selectedIndex < 0)
+        {
+            for (uint i = 0; i < playbackItem.TimedMetadataTracks.Count; i++)
+            {
+                playbackItem.TimedMetadataTracks.SetPresentationMode(i, TimedMetadataTrackPresentationMode.Disabled);
+            }
+
+            return;
+        }
+
+        int? uwpIndex = GetSubtitleUwpIndex(selectedIndex);
+        if (!uwpIndex.HasValue || uwpIndex.Value >= playbackItem.TimedMetadataTracks.Count)
+        {
+            return;
+        }
+
+        for (uint i = 0; i < playbackItem.TimedMetadataTracks.Count; i++)
+        {
+            var mode = i == uwpIndex.Value
+                ? TimedMetadataTrackPresentationMode.PlatformPresented
+                : TimedMetadataTrackPresentationMode.Disabled;
+            playbackItem.TimedMetadataTracks.SetPresentationMode(i, mode);
+        }
     }
 
     /// <summary>
@@ -162,15 +189,7 @@ internal sealed partial class VideoViewModel
 
         if (canSeamlessSwitch)
         {
-            // Set each track's presentation mode in a single pass
-            for (uint i = 0; i < _currentPlaybackItem!.TimedMetadataTracks.Count; i++)
-            {
-                var mode = i == track.UwpTrackIndex
-                    ? TimedMetadataTrackPresentationMode.PlatformPresented
-                    : TimedMetadataTrackPresentationMode.Disabled;
-                _currentPlaybackItem.TimedMetadataTracks.SetPresentationMode(i, mode);
-            }
-
+            PresentSelectedSubtitleTrack(_currentPlaybackItem!);
             Debug.WriteLine(track.UwpTrackIndex.HasValue
                 ? $"Seamless subtitle switch to Jellyfin index {track.JellyfinIndex} (UWP index {track.UwpTrackIndex})"
                 : "Subtitles disabled");

--- a/src/JellyBox/ViewModels/VideoViewModel.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.cs
@@ -3,6 +3,7 @@ using JellyBox.Controls;
 using JellyBox.Services;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using System.Net.Http;
 using Windows.Media.Playback;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -14,6 +15,7 @@ internal sealed partial class VideoViewModel : ObservableObject
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
     private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly JellyfinImageResolver _imageResolver;
     private readonly JellyfinSdkSettings _sdkClientSettings;
     private readonly DeviceProfileManager _deviceProfileManager;
@@ -26,14 +28,17 @@ internal sealed partial class VideoViewModel : ObservableObject
     private MediaPlaybackItem? _currentPlaybackItem;
     private double _volumeBeforeMute = 1.0;
     private bool _isDirectPlay;
+    private int? _cachedMaxStreamingBitrate;
 
     public VideoViewModel(
         JellyfinApiClient jellyfinApiClient,
+        IHttpClientFactory httpClientFactory,
         JellyfinImageResolver imageResolver,
         JellyfinSdkSettings sdkClientSettings,
         DeviceProfileManager deviceProfileManager)
     {
         _jellyfinApiClient = jellyfinApiClient;
+        _httpClientFactory = httpClientFactory;
         _imageResolver = imageResolver;
         _sdkClientSettings = sdkClientSettings;
         _deviceProfileManager = deviceProfileManager;

--- a/src/JellyBox/Views/Home.xaml
+++ b/src/JellyBox/Views/Home.xaml
@@ -20,7 +20,7 @@
                 x:Name="SectionsControl"
                 ItemsSource="{x:Bind ViewModel.Sections, Mode=OneWay}"
                 ItemTemplate="{StaticResource Section}"
-                Margin="0,48,0,48"
+                Margin="0,16,0,48"
                 XYFocusKeyboardNavigation="Enabled">
                 <Interactivity:Interaction.Behaviors>
                     <Behaviors:SectionNavigationBehavior

--- a/src/JellyBox/Views/Home.xaml.cs
+++ b/src/JellyBox/Views/Home.xaml.cs
@@ -19,7 +19,11 @@ internal sealed partial class Home : Page
         SectionsControl.LayoutUpdated += SectionsControl_LayoutUpdated;
     }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.Initialize();
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        _hasFocusedFirstItem = false;
+        ViewModel.Initialize();
+    }
 
     public HomeViewModel ViewModel { get; }
 

--- a/src/JellyBox/Views/ItemDetails.xaml
+++ b/src/JellyBox/Views/ItemDetails.xaml
@@ -250,7 +250,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedSourceContainer.Value.Name, Mode=OneWay}"
+                                    Text="{x:Bind GetSourceContainerName(ViewModel.SelectedSourceContainer), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -285,7 +285,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedSourceContainer.Value.Name, Mode=OneWay}"
+                                Text="{x:Bind GetSourceContainerName(ViewModel.SelectedSourceContainer), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>
@@ -312,7 +312,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedAudioStream.DisplayText, Mode=OneWay}"
+                                    Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedAudioStream), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -347,7 +347,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedAudioStream.DisplayText, Mode=OneWay}"
+                                Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedAudioStream), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>
@@ -374,7 +374,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedSubtitleStream.DisplayText, Mode=OneWay}"
+                                    Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedSubtitleStream), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -409,7 +409,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedSubtitleStream.DisplayText, Mode=OneWay}"
+                                Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedSubtitleStream), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>

--- a/src/JellyBox/Views/ItemDetails.xaml
+++ b/src/JellyBox/Views/ItemDetails.xaml
@@ -63,7 +63,7 @@
             VerticalScrollBarVisibility="Hidden"
             BringIntoViewOnFocusChange="False"
             IsTabStop="False">
-            <Grid x:Name="ContentGrid" XYFocusKeyboardNavigation="Enabled" Margin="48,100,48,48">
+            <Grid x:Name="ContentGrid" XYFocusKeyboardNavigation="Enabled" Margin="48,24,48,48">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="380" />
                     <ColumnDefinition Width="*" />

--- a/src/JellyBox/Views/ItemDetails.xaml.cs
+++ b/src/JellyBox/Views/ItemDetails.xaml.cs
@@ -41,6 +41,9 @@ internal sealed partial class ItemDetails : Page
         ViewModel.HandleParameters((Parameters)e.Parameter);
     }
 
+    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        => ViewModel.CancelLoading();
+
     internal sealed record Parameters(Guid ItemId);
 
     #region Initial Focus
@@ -240,6 +243,16 @@ internal sealed partial class ItemDetails : Page
     private Style GetPlayButtonStyle(bool canResume)
 #pragma warning restore CA1822
         => (Style)Application.Current.Resources[canResume ? "SecondaryButton" : "PrimaryButton"];
+
+#pragma warning disable CA1822 // Used by x:Bind
+    private string GetSourceContainerName(MediaSourceInfoWrapper? source)
+#pragma warning restore CA1822
+        => source?.Value?.Name ?? string.Empty;
+
+#pragma warning disable CA1822 // Used by x:Bind
+    private string GetStreamDisplayText(MediaStreamOption? stream)
+#pragma warning restore CA1822
+        => stream?.DisplayText ?? string.Empty;
 
     private bool IsActionButton(object? element)
         => ReferenceEquals(element, ResumeButton)

--- a/src/JellyBox/Views/ItemDetails.xaml.cs
+++ b/src/JellyBox/Views/ItemDetails.xaml.cs
@@ -32,7 +32,14 @@ internal sealed partial class ItemDetails : Page
 
     internal ItemDetailsViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        _hasFocusedInitial = false;
+        _lastNavigationDirection = null;
+        ContentInfoPanel.LayoutUpdated -= ContentInfoPanel_LayoutUpdated;
+        ContentInfoPanel.LayoutUpdated += ContentInfoPanel_LayoutUpdated;
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+    }
 
     internal sealed record Parameters(Guid ItemId);
 

--- a/src/JellyBox/Views/Library.xaml
+++ b/src/JellyBox/Views/Library.xaml
@@ -101,12 +101,11 @@
                     x:Name="FilterButton"
                     Background="{StaticResource BackgroundElevated}"
                     Foreground="{StaticResource TextPrimary}"
-                    BorderBrush="{x:Bind viewmodels:LibraryViewModel.GetFilterBorderBrush(ViewModel.HasActiveFilters), Mode=OneWay}"
+                    BorderBrush="{StaticResource BorderSubtle}"
                     BorderThickness="1"
                     Padding="16,8"
                     CornerRadius="4"
-                    XYFocusKeyboardNavigation="Enabled"
-                    XYFocusRight="{x:Bind viewmodels:LibraryViewModel.GetFilterXYFocusRight(ViewModel.HasActiveFilters, FilterButton, ClearFiltersButton), Mode=OneWay}">
+                    XYFocusKeyboardNavigation="Enabled">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontFamily="{StaticResource SegoeIcons}" Glyph="&#xE71C;" FontSize="16" />
                         <TextBlock Text="Filter" FontSize="{StaticResource FontS}" />
@@ -176,8 +175,7 @@
                     Foreground="{StaticResource AccentColor}"
                     BorderThickness="0"
                     Padding="12,8"
-                    CornerRadius="4"
-                    XYFocusRight="{x:Bind ClearFiltersButton}">
+                    CornerRadius="4">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon FontFamily="{StaticResource SegoeIcons}" Glyph="&#xE711;" FontSize="12" />
                         <TextBlock Text="Clear Filters" FontSize="{StaticResource FontS}" />

--- a/src/JellyBox/Views/Library.xaml
+++ b/src/JellyBox/Views/Library.xaml
@@ -18,7 +18,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header: Title + Toolbar -->
-        <StackPanel Grid.Row="0" Padding="48,24,48,0">
+        <StackPanel Grid.Row="0" Padding="48,16,48,0">
             <TextBlock
                 Text="{x:Bind ViewModel.Title, Mode=OneWay}"
                 FontSize="{StaticResource FontXL}"

--- a/src/JellyBox/Views/Library.xaml.cs
+++ b/src/JellyBox/Views/Library.xaml.cs
@@ -1,22 +1,69 @@
+using System.ComponentModel;
 using JellyBox.ViewModels;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
 namespace JellyBox.Views;
 
 internal sealed partial class Library : Page
 {
+    private bool _filterChromeAttached;
+
     public Library()
     {
         InitializeComponent();
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<LibraryViewModel>();
+        Loaded += OnLoaded;
     }
 
     internal LibraryViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+        UpdateFilterChrome();
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_filterChromeAttached)
+        {
+            return;
+        }
+
+        _filterChromeAttached = true;
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        UpdateFilterChrome();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(LibraryViewModel.HasActiveFilters))
+        {
+            UpdateFilterChrome();
+        }
+    }
+
+    private void UpdateFilterChrome()
+    {
+        if (!IsLoaded)
+        {
+            return;
+        }
+
+        string resourceKey = ViewModel.HasActiveFilters ? "AccentColor" : "BorderSubtle";
+        if (Application.Current.Resources[resourceKey] is Brush brush)
+        {
+            FilterButton.BorderBrush = brush;
+        }
+
+        FilterButton.XYFocusRight = ViewModel.HasActiveFilters ? ClearFiltersButton : FilterButton;
+        ClearFiltersButton.XYFocusRight = ClearFiltersButton;
+    }
 
     private void SortListView_ItemClick(object sender, ItemClickEventArgs e)
     {

--- a/src/JellyBox/Views/Login.xaml.cs
+++ b/src/JellyBox/Views/Login.xaml.cs
@@ -1,6 +1,6 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
@@ -33,7 +33,7 @@ internal sealed partial class Login : Page
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key is VirtualKey.Enter or VirtualKey.GamepadMenu
+        if (GamepadInput.IsAcceptKey(e.Key)
             && ViewModel.SignInCommand.CanExecute(null))
         {
             ViewModel.SignInCommand.Execute(null);

--- a/src/JellyBox/Views/Search.xaml
+++ b/src/JellyBox/Views/Search.xaml
@@ -1,0 +1,62 @@
+<Page
+    x:Class="JellyBox.Views.Search"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Behaviors="using:JellyBox.Behaviors"
+    xmlns:controls="using:JellyBox.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{StaticResource BackgroundBase}">
+
+    <Grid XYFocusKeyboardNavigation="Enabled">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Padding="48,16,48,8" Spacing="4">
+            <TextBlock
+                Text="{x:Bind ViewModel.ResultsTitle, Mode=OneWay}"
+                FontSize="{StaticResource FontXL}"
+                FontWeight="SemiBold"
+                Foreground="{StaticResource TextPrimary}" />
+            <TextBlock
+                Text="{x:Bind ViewModel.ResultsSubtitle, Mode=OneWay}"
+                FontSize="{StaticResource FontS}"
+                Foreground="{StaticResource TextMuted}" />
+        </StackPanel>
+
+        <GridView
+            Grid.Row="1"
+            Padding="48,8,48,48"
+            ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}"
+            ItemTemplate="{StaticResource Card}"
+            ItemContainerStyle="{StaticResource CardGridViewItemStyle}"
+            SelectionMode="None"
+            IsItemClickEnabled="True"
+            SingleSelectionFollowsFocus="False"
+            TabNavigation="Once"
+            IsTabStop="False"
+            XYFocusKeyboardNavigation="Enabled"
+            ScrollViewer.VerticalScrollBarVisibility="Hidden"
+            ScrollViewer.VerticalScrollMode="Enabled"
+            ScrollViewer.HorizontalScrollMode="Disabled"
+            ScrollViewer.BringIntoViewOnFocusChange="False"
+            Visibility="{x:Bind ViewModel.ShowEmptyState, Mode=OneWay, Converter={StaticResource NegateConverter}}">
+            <Interactivity:Interaction.Behaviors>
+                <Behaviors:FocusFirstItemBehavior />
+                <Behaviors:ListViewBaseCommandBehavior />
+                <Behaviors:ScrollOnFocusBehavior SafeZoneMargin="48" EnableVerticalScroll="True" TrapFocusAtRightEdge="False" TopOffset="100" />
+            </Interactivity:Interaction.Behaviors>
+            <GridView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsWrapGrid Orientation="Horizontal" HorizontalAlignment="Center" />
+                </ItemsPanelTemplate>
+            </GridView.ItemsPanel>
+        </GridView>
+
+        <controls:LoadingOverlay Grid.Row="1" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+    </Grid>
+</Page>

--- a/src/JellyBox/Views/Search.xaml.cs
+++ b/src/JellyBox/Views/Search.xaml.cs
@@ -1,0 +1,22 @@
+using JellyBox.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace JellyBox.Views;
+
+internal sealed partial class Search : Page
+{
+    public Search()
+    {
+        InitializeComponent();
+        ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<SearchViewModel>();
+    }
+
+    internal SearchViewModel ViewModel { get; }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+        => ViewModel.HandleParameters((Parameters)e.Parameter);
+
+    internal sealed record Parameters(string Query);
+}

--- a/src/JellyBox/Views/ServerSelection.xaml.cs
+++ b/src/JellyBox/Views/ServerSelection.xaml.cs
@@ -1,6 +1,6 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
@@ -20,7 +20,7 @@ internal sealed partial class ServerSelection : Page
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key is VirtualKey.Enter or VirtualKey.GamepadMenu
+        if (GamepadInput.IsAcceptKey(e.Key)
             && ViewModel.ConnectCommand.CanExecute(null))
         {
             ViewModel.ConnectCommand.Execute(null);

--- a/src/JellyBox/Views/Video.xaml.cs
+++ b/src/JellyBox/Views/Video.xaml.cs
@@ -1,4 +1,5 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.System;
@@ -41,8 +42,10 @@ internal sealed partial class Video : Page
         object? focused = FocusManager.GetFocusedElement();
         bool hasControlFocus = focused is Control and not Page;
 
+        VirtualKey key = args.VirtualKey;
+
         // Handle Xbox controller and keyboard shortcuts
-        switch (args.VirtualKey)
+        switch (key)
         {
             // Controller: LB, Keyboard: J - Rewind 10 seconds
             case VirtualKey.GamepadLeftShoulder:
@@ -68,10 +71,14 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Controller: Menu, Keyboard: Space/K - Play/Pause
+            // Controller: A / Menu, Keyboard: Space/K - Play/Pause
+            case VirtualKey.GamepadA:
             case VirtualKey.GamepadMenu:
-                ViewModel.TogglePlayPause();
-                args.Handled = true;
+                if (!hasControlFocus || key is VirtualKey.GamepadMenu)
+                {
+                    ViewModel.TogglePlayPause();
+                    args.Handled = true;
+                }
                 break;
 
             case VirtualKey.Space:
@@ -83,7 +90,8 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Keyboard: M - Toggle mute
+            // Controller: X, Keyboard: M - Toggle mute
+            case VirtualKey.GamepadX:
             case VirtualKey.M:
                 if (!hasControlFocus)
                 {
@@ -92,46 +100,38 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Keyboard: Up/Down arrow - Volume control (when not on a control)
-            case VirtualKey.Up:
+            default:
                 if (!hasControlFocus)
                 {
-                    ViewModel.AdjustVolume(0.1);
-                    args.Handled = true;
+                    if (GamepadInput.IsVolumeUpKey(key))
+                    {
+                        ViewModel.AdjustVolume(0.1);
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsVolumeDownKey(key))
+                    {
+                        ViewModel.AdjustVolume(-0.1);
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsSeekBackwardKey(key))
+                    {
+                        ViewModel.Rewind();
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsSeekForwardKey(key))
+                    {
+                        ViewModel.FastForward();
+                        args.Handled = true;
+                    }
                 }
-                break;
 
-            case VirtualKey.Down:
-                if (!hasControlFocus)
-                {
-                    ViewModel.AdjustVolume(-0.1);
-                    args.Handled = true;
-                }
                 break;
+        }
 
-            // Keyboard: Left/Right arrow - Seek (when not on a control)
-            case VirtualKey.Left:
-                if (!hasControlFocus)
-                {
-                    ViewModel.Rewind();
-                    args.Handled = true;
-                }
-                break;
-
-            case VirtualKey.Right:
-                if (!hasControlFocus)
-                {
-                    ViewModel.FastForward();
-                    args.Handled = true;
-                }
-                break;
-
-            // Keyboard: Escape - Go back
-            case VirtualKey.Escape:
-            case VirtualKey.GamepadB:
-                Frame.GoBack();
-                args.Handled = true;
-                break;
+        if (!args.Handled && GamepadInput.IsBackKey(key))
+        {
+            Frame.GoBack();
+            args.Handled = true;
         }
     }
 

--- a/src/JellyBox/Views/WebVideo.xaml.cs
+++ b/src/JellyBox/Views/WebVideo.xaml.cs
@@ -1,4 +1,7 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -15,12 +18,27 @@ internal sealed partial class WebVideo : Page
 
     internal WebVideoViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+        Window.Current.CoreWindow.KeyDown += OnCoreWindowKeyDown;
+    }
 
     protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
     {
+        Window.Current.CoreWindow.KeyDown -= OnCoreWindowKeyDown;
+
         // Dispose of the webview to stop the video
         WebView2.Close();
+    }
+
+    private void OnCoreWindowKeyDown(CoreWindow sender, KeyEventArgs args)
+    {
+        if (GamepadInput.IsBackKey(args.VirtualKey))
+        {
+            Frame.GoBack();
+            args.Handled = true;
+        }
     }
 
     internal sealed record Parameters(Uri VideoUri);


### PR DESCRIPTION
## Summary

This PR improves JellyBox build reliability, subtitle playback, Xbox Series X/S controller navigation, shell-level search, and library browsing on console.

It includes the work from #88 plus additional controller, search, and navigation features.

### Build and restore (VS 2026 / CPM)
- Fix Central Package Management discovery via `DirectoryPackagesPropsPath`
- Pin Kiota packages to 1.22.0 (addresses NU1903)
- Harden appx manifest versioning for Visual Studio builds
- Add `win-x64.pubxml` publish profile for Native AOT Xbox sideload builds
- Target Xbox OS 22000+ in manifest and use `JellyBox.exe` entry point for AOT packages

### Subtitle playback
- Load only the selected external subtitle stream when the client can render subtitles
- Reduce subtitle track churn and dispatcher overhead during playback
- Cache max streaming bitrate per playback session

### Xbox controller and navigation
- Centralize gamepad input in `GamepadInput` and handle shell navigation at the CoreWindow level
- Map video controls (A play/pause, X mute, sticks/D-pad volume and seek, LB/RB skip)
- Support B/View/Menu consistently across shell pages
- Add `ShellFocusCoordinator` so search is not auto-focused; fix invalid `FocusState.Unfocused` crash on navigation

### Search
- Persistent search bar in the main shell with debounced Jellyfin hints
- Search results page with portrait cards
- Fixes for AutoSuggestBox binding and navigation races when opening item details

### Library navigation
- Route Home "My Media" collection tiles through the same path as the side menu (`NavigateToItem(BaseItemDto)`)
- Add `CollectionNavigation` mapping for Movies, TV Shows, Collections (box sets), and Books
- Move library filter toolbar XYFocus bindings to code-behind for Xbox stability

## Test plan
- [x] Release/Debug x64 build succeeds in VS 2026
- [x] App launches and browses library/home on Xbox Series X (dev mode)
- [x] Side menu: Movies, TV Shows, Collections, and Books open library views
- [x] Home: Movies and TV Shows tiles open the same library views as the side menu
- [x] Subtitle playback without severe lag
- [x] Search finds movies and TV shows; selecting opens item details
- [x] Xbox navigation and search focus behavior verified on hardware

## Notes
- Supersedes #88; that PR can be closed in favor of this one if preferred.
- Music/Photos libraries still fall back to item details until explicitly mapped.