### PR TITLE
Avoid SetAppxManifestVersion for design-time builds

### DIFF
--- a/src/JellyBox/JellyBox.csproj
+++ b/src/JellyBox/JellyBox.csproj
@@ -41,7 +41,8 @@
   </ItemGroup>
   <Target Name="SetAppxManifestVersion"
           BeforeTargets="PrepareForBuild"
-          DependsOnTargets="GetBuildVersion">
+          DependsOnTargets="GetBuildVersion"
+          Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingProject)' == 'true'">
     <ItemGroup>
       <_OriginalAppxManifest Include="@(AppxManifest)" />
       <AppxManifest Remove="@(AppxManifest)" />


### PR DESCRIPTION
Avoids errors like this in VS if you didn't do an explicit command-line restore:

```
1>D:\Code\JellyBox\src\JellyBox\JellyBox.csproj(44,11): error MSB4057: The target "GetBuildVersion" does not exist in the project.
```