### PR TITLE
Add Xbox Series X controller support and shell navigation

### DIFF
--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,6 +1,5 @@
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -22,8 +21,6 @@ internal sealed partial class MainPage : Page
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
-
-        KeyDown += OnKeyDown;
 
         SlideInAnimation.Completed += SlideInCompleted;
 
@@ -112,88 +109,6 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
-    }
-
-    /// <summary>
-    /// Keyboard and gamepad input handling.
-    /// Only handles commands and nav-menu-specific logic.
-    /// Directional focus movement is handled by XYFocusKeyboardNavigation in XAML.
-    /// </summary>
-    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        // Don't intercept keys when a text input control has focus
-        if (FocusManager.GetFocusedElement() is TextBox or PasswordBox)
-        {
-            return;
-        }
-
-        switch (e.Key)
-        {
-            // Back gesture - close navigation if open
-            case VirtualKey.Back:
-            case VirtualKey.GamepadB:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Toggle navigation menu
-            case VirtualKey.GamepadMenu:
-            case VirtualKey.GamepadView:
-            case VirtualKey.M:
-            {
-                ViewModel.ToggleNavigationCommand.Execute(null);
-                e.Handled = true;
-                break;
-            }
-
-            // Close navigation menu
-            case VirtualKey.Escape:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Right closes nav menu when open
-            case VirtualKey.Right:
-            case VirtualKey.GamepadDPadRight:
-            case VirtualKey.GamepadLeftThumbstickRight:
-            case VirtualKey.NavigationRight:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Left at edge opens nav menu
-            case VirtualKey.Left:
-            case VirtualKey.GamepadDPadLeft:
-            case VirtualKey.GamepadLeftThumbstickLeft:
-            case VirtualKey.NavigationLeft:
-            {
-                if (!ViewModel.IsMenuOpen && !FocusManager.TryMoveFocus(FocusNavigationDirection.Left))
-                {
-                    ViewModel.OpenNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-        }
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/Resources/TransportControlsStyles.xaml
+++ b/src/JellyBox/Resources/TransportControlsStyles.xaml
@@ -115,7 +115,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Rewind"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RewindCommand}"
-                                                      ToolTipService.ToolTip="Rewind 10 seconds (LB)"
+                                                      ToolTipService.ToolTip="Rewind 10 seconds (LB / D-pad left)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon Glyph="&#xED3C;" FontFamily="Segoe MDL2 Assets" />
@@ -127,7 +127,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Play"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PlayPauseCommand}"
-                                                      ToolTipService.ToolTip="Play/Pause (Space)"
+                                                      ToolTipService.ToolTip="Play/Pause (A / Menu / Space)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon x:Name="CustomPlayPauseIcon" Glyph="&#xE768;" FontFamily="Segoe MDL2 Assets" />
@@ -139,7 +139,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Fast Forward"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FastForwardCommand}"
-                                                      ToolTipService.ToolTip="Fast forward 30 seconds (RB)"
+                                                      ToolTipService.ToolTip="Fast forward 30 seconds (RB / D-pad right)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon Glyph="&#xED3D;" FontFamily="Segoe MDL2 Assets" />
@@ -172,7 +172,7 @@
                                         <Button x:Name="CustomVolumeButton"
                                                 Style="{StaticResource TransportIconButtonStyle}"
                                                 Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ToggleMuteCommand}"
-                                                ToolTipService.ToolTip="Toggle mute (M)"
+                                                ToolTipService.ToolTip="Toggle mute (X / M)"
                                                 XYFocusKeyboardNavigation="Enabled">
                                             <FontIcon x:Name="CustomVolumeIcon" Glyph="&#xE767;" FontFamily="Segoe MDL2 Assets" />
                                             <Button.Flyout>

--- a/src/JellyBox/Services/GamepadInput.cs
+++ b/src/JellyBox/Services/GamepadInput.cs
@@ -1,0 +1,55 @@
+using Windows.System;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace JellyBox.Services;
+
+/// <summary>
+/// Shared Xbox / gamepad virtual-key helpers for consistent controller input across the app.
+/// </summary>
+internal static class GamepadInput
+{
+    public static bool IsTextInputFocused()
+        => FocusManager.GetFocusedElement() is TextBox or PasswordBox;
+
+    public static bool IsAcceptKey(VirtualKey key)
+        => key is VirtualKey.Enter or VirtualKey.GamepadA or VirtualKey.Space;
+
+    public static bool IsBackKey(VirtualKey key)
+        => key is VirtualKey.Back or VirtualKey.Escape or VirtualKey.GamepadB or VirtualKey.GoBack;
+
+    public static bool IsMenuToggleKey(VirtualKey key)
+        => key is VirtualKey.GamepadMenu or VirtualKey.GamepadView or VirtualKey.M;
+
+    public static bool IsNavigateLeftKey(VirtualKey key)
+        => key is VirtualKey.Left
+            or VirtualKey.GamepadDPadLeft
+            or VirtualKey.GamepadLeftThumbstickLeft
+            or VirtualKey.NavigationLeft;
+
+    public static bool IsNavigateRightKey(VirtualKey key)
+        => key is VirtualKey.Right
+            or VirtualKey.GamepadDPadRight
+            or VirtualKey.GamepadLeftThumbstickRight
+            or VirtualKey.NavigationRight;
+
+    public static bool IsVolumeUpKey(VirtualKey key)
+        => key is VirtualKey.Up
+            or VirtualKey.GamepadDPadUp
+            or VirtualKey.GamepadLeftThumbstickUp;
+
+    public static bool IsVolumeDownKey(VirtualKey key)
+        => key is VirtualKey.Down
+            or VirtualKey.GamepadDPadDown
+            or VirtualKey.GamepadLeftThumbstickDown;
+
+    public static bool IsSeekBackwardKey(VirtualKey key)
+        => key is VirtualKey.Left
+            or VirtualKey.GamepadDPadLeft
+            or VirtualKey.GamepadLeftThumbstickLeft;
+
+    public static bool IsSeekForwardKey(VirtualKey key)
+        => key is VirtualKey.Right
+            or VirtualKey.GamepadDPadRight
+            or VirtualKey.GamepadLeftThumbstickRight;
+}

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -16,7 +16,20 @@ internal sealed class NavigationManager
     // Fake item id used to identify the home page
     public static readonly Guid HomeId = new Guid("CDF95D47-90C2-4057-B12C-BA81C34F2CB9");
 
-    public event Action? MenuOpenRequested;
+    /// <summary>
+    /// Opens the shell navigation menu.
+    /// </summary>
+    public Action? OpenNavigationMenu { get; set; }
+
+    /// <summary>
+    /// Toggles the shell navigation menu.
+    /// </summary>
+    public Action? ToggleNavigationMenu { get; set; }
+
+    /// <summary>
+    /// Closes the shell navigation menu when open. Returns true if the menu was closed.
+    /// </summary>
+    public Func<bool>? TryCloseNavigationMenu { get; set; }
 
     private Frame _appFrame = null!; // TODO
 
@@ -45,6 +58,7 @@ internal sealed class NavigationManager
 
         SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
         Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += AcceleratorKeyActivated;
+        Window.Current.CoreWindow.KeyDown += CoreWindowKeyDown;
         Window.Current.CoreWindow.PointerPressed += PointerPressed;
     }
 
@@ -72,7 +86,7 @@ internal sealed class NavigationManager
 
     public void NavigateToLogin() => NavigateAppFrame<Login>();
 
-    public void RequestOpenMenu() => MenuOpenRequested?.Invoke();
+    public void RequestOpenMenu() => OpenNavigationMenu?.Invoke();
 
     public void NavigateToHome()
     {
@@ -235,8 +249,7 @@ internal sealed class NavigationManager
             return;
         }
 
-        // Don't intercept navigation keys when a text input control has focus
-        if (FocusManager.GetFocusedElement() is TextBox or PasswordBox)
+        if (GamepadInput.IsTextInputFocused())
         {
             return;
         }
@@ -250,9 +263,18 @@ internal sealed class NavigationManager
         bool onlyAlt = menuKey && !controlKey && !shiftKey;
         VirtualKey virtualKey = e.VirtualKey;
 
-        if ((virtualKey is VirtualKey.GoBack && noModifiers)
-            || (virtualKey is VirtualKey.Left && onlyAlt)
-            || (virtualKey is VirtualKey.Back && noModifiers))
+        if (GamepadInput.IsBackKey(virtualKey) && noModifiers)
+        {
+            if (TryCloseNavigationMenu?.Invoke() == true)
+            {
+                e.Handled = true;
+            }
+            else
+            {
+                e.Handled = GoBack();
+            }
+        }
+        else if (virtualKey is VirtualKey.Left && onlyAlt)
         {
             e.Handled = GoBack();
         }
@@ -260,6 +282,46 @@ internal sealed class NavigationManager
             || (virtualKey is VirtualKey.Right && onlyAlt))
         {
             e.Handled = GoForward();
+        }
+    }
+
+    /// <summary>
+    /// Global gamepad and keyboard shortcuts for the main app shell (home, library, details).
+    /// Full-screen pages such as video playback register their own handlers.
+    /// </summary>
+    private void CoreWindowKeyDown(CoreWindow sender, KeyEventArgs e)
+    {
+        // Shell shortcuts only apply inside MainPage content (login/video use app-frame pages).
+        if (_contentFrame is null || GamepadInput.IsTextInputFocused())
+        {
+            return;
+        }
+
+        VirtualKey key = e.VirtualKey;
+
+        if (GamepadInput.IsMenuToggleKey(key))
+        {
+            ToggleNavigationMenu?.Invoke();
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsBackKey(key) && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsNavigateRightKey(key) && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsNavigateLeftKey(key) && !FocusManager.TryMoveFocus(FocusNavigationDirection.Left))
+        {
+            OpenNavigationMenu?.Invoke();
+            e.Handled = true;
         }
     }
 

--- a/src/JellyBox/ViewModels/MainPageViewModel.cs
+++ b/src/JellyBox/ViewModels/MainPageViewModel.cs
@@ -34,7 +34,18 @@ internal sealed partial class MainPageViewModel : ObservableObject
         _appSettings = appSettings;
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
-        _navigationManager.MenuOpenRequested += () => IsMenuOpen = true;
+        _navigationManager.OpenNavigationMenu = () => OpenNavigationCommand.Execute(null);
+        _navigationManager.ToggleNavigationMenu = () => ToggleNavigationCommand.Execute(null);
+        _navigationManager.TryCloseNavigationMenu = () =>
+        {
+            if (!IsMenuOpen)
+            {
+                return false;
+            }
+
+            CloseNavigationCommand.Execute(null);
+            return true;
+        };
     }
 
     [RelayCommand]

--- a/src/JellyBox/Views/ItemDetails.xaml.cs
+++ b/src/JellyBox/Views/ItemDetails.xaml.cs
@@ -85,7 +85,7 @@ internal sealed partial class ItemDetails : Page
         {
             e.TryCancel();
 
-            // XY focus consumes the key even when cancelled, so MainPage.OnKeyDown never fires.
+            // XY focus consumes the key before NavigationManager can open the menu from left-edge input.
             // Open the nav menu directly for left-edge presses.
             if (e.Direction == FocusNavigationDirection.Left)
             {

--- a/src/JellyBox/Views/Login.xaml.cs
+++ b/src/JellyBox/Views/Login.xaml.cs
@@ -1,6 +1,6 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
@@ -33,7 +33,7 @@ internal sealed partial class Login : Page
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key is VirtualKey.Enter or VirtualKey.GamepadMenu
+        if (GamepadInput.IsAcceptKey(e.Key)
             && ViewModel.SignInCommand.CanExecute(null))
         {
             ViewModel.SignInCommand.Execute(null);

--- a/src/JellyBox/Views/ServerSelection.xaml.cs
+++ b/src/JellyBox/Views/ServerSelection.xaml.cs
@@ -1,6 +1,6 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
@@ -20,7 +20,7 @@ internal sealed partial class ServerSelection : Page
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key is VirtualKey.Enter or VirtualKey.GamepadMenu
+        if (GamepadInput.IsAcceptKey(e.Key)
             && ViewModel.ConnectCommand.CanExecute(null))
         {
             ViewModel.ConnectCommand.Execute(null);

--- a/src/JellyBox/Views/Video.xaml.cs
+++ b/src/JellyBox/Views/Video.xaml.cs
@@ -1,4 +1,5 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.System;
@@ -41,8 +42,10 @@ internal sealed partial class Video : Page
         object? focused = FocusManager.GetFocusedElement();
         bool hasControlFocus = focused is Control and not Page;
 
+        VirtualKey key = args.VirtualKey;
+
         // Handle Xbox controller and keyboard shortcuts
-        switch (args.VirtualKey)
+        switch (key)
         {
             // Controller: LB, Keyboard: J - Rewind 10 seconds
             case VirtualKey.GamepadLeftShoulder:
@@ -68,7 +71,17 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Controller: Menu, Keyboard: Space/K - Play/Pause
+            // Controller: A, Keyboard: Space/K - Play/Pause (when transport controls are not focused)
+            case VirtualKey.GamepadA:
+                if (!hasControlFocus)
+                {
+                    ViewModel.TogglePlayPause();
+                    args.Handled = true;
+                }
+
+                break;
+
+            // Controller: Menu - Play/Pause globally
             case VirtualKey.GamepadMenu:
                 ViewModel.TogglePlayPause();
                 args.Handled = true;
@@ -83,7 +96,8 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Keyboard: M - Toggle mute
+            // Controller: X, Keyboard: M - Toggle mute
+            case VirtualKey.GamepadX:
             case VirtualKey.M:
                 if (!hasControlFocus)
                 {
@@ -92,46 +106,38 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Keyboard: Up/Down arrow - Volume control (when not on a control)
-            case VirtualKey.Up:
+            default:
                 if (!hasControlFocus)
                 {
-                    ViewModel.AdjustVolume(0.1);
-                    args.Handled = true;
+                    if (GamepadInput.IsVolumeUpKey(key))
+                    {
+                        ViewModel.AdjustVolume(0.1);
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsVolumeDownKey(key))
+                    {
+                        ViewModel.AdjustVolume(-0.1);
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsSeekBackwardKey(key))
+                    {
+                        ViewModel.Rewind();
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsSeekForwardKey(key))
+                    {
+                        ViewModel.FastForward();
+                        args.Handled = true;
+                    }
                 }
-                break;
 
-            case VirtualKey.Down:
-                if (!hasControlFocus)
-                {
-                    ViewModel.AdjustVolume(-0.1);
-                    args.Handled = true;
-                }
                 break;
+        }
 
-            // Keyboard: Left/Right arrow - Seek (when not on a control)
-            case VirtualKey.Left:
-                if (!hasControlFocus)
-                {
-                    ViewModel.Rewind();
-                    args.Handled = true;
-                }
-                break;
-
-            case VirtualKey.Right:
-                if (!hasControlFocus)
-                {
-                    ViewModel.FastForward();
-                    args.Handled = true;
-                }
-                break;
-
-            // Keyboard: Escape - Go back
-            case VirtualKey.Escape:
-            case VirtualKey.GamepadB:
-                Frame.GoBack();
-                args.Handled = true;
-                break;
+        if (!args.Handled && GamepadInput.IsBackKey(key))
+        {
+            Frame.GoBack();
+            args.Handled = true;
         }
     }
 

--- a/src/JellyBox/Views/WebVideo.xaml.cs
+++ b/src/JellyBox/Views/WebVideo.xaml.cs
@@ -1,4 +1,7 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -15,12 +18,27 @@ internal sealed partial class WebVideo : Page
 
     internal WebVideoViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+        Window.Current.CoreWindow.KeyDown += OnCoreWindowKeyDown;
+    }
 
     protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
     {
+        Window.Current.CoreWindow.KeyDown -= OnCoreWindowKeyDown;
+
         // Dispose of the webview to stop the video
         WebView2.Close();
+    }
+
+    private void OnCoreWindowKeyDown(CoreWindow sender, KeyEventArgs args)
+    {
+        if (GamepadInput.IsBackKey(args.VirtualKey))
+        {
+            Frame.GoBack();
+            args.Handled = true;
+        }
     }
 
     internal sealed record Parameters(Uri VideoUri);


### PR DESCRIPTION
## Summary

Adds Xbox Series X/S controller support and shell-level navigation. Builds on #88.

### Controller and shell navigation
- Centralize gamepad virtual-key handling in `GamepadInput`
- Route shell navigation (menu toggle, left-edge open, B/Escape back) through `NavigationManager` at the CoreWindow level so it works on every content page
- Map video controls: A play/pause, X mute, D-pad/stick volume and seek, LB/RB skip
- Login and server selection accept Gamepad A to submit
- WebVideo supports B to go back

## Merge order

This PR stacks on **#88** (`fix/build-and-subtitle-playback`). Please merge #88 first, then this one.

Part of splitting the former #89 into bite-sized reviews. Follow-up: shell search PR stacks on this branch.

## Test plan
- [x] App launches on Xbox Series X (dev mode)
- [x] B/View navigates back from shell pages
- [x] Menu button toggles navigation pane
- [x] Left on content edge opens navigation menu
- [x] Video playback responds to A/X/sticks/D-pad/LB/RB