### PR TITLE
Route collection folders to library views

### DIFF
--- a/src/JellyBox/App.xaml.cs
+++ b/src/JellyBox/App.xaml.cs
@@ -40,9 +40,20 @@ sealed partial class App : Application
 
         InitializeComponent();
 
+        UnhandledException += OnUnhandledException;
+
         Current.RequiresPointerMode = ApplicationRequiresPointerMode.WhenRequested;
 
         Suspending += OnSuspending;
+    }
+
+    private void OnUnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine($"Unhandled UI exception: {e.Exception}");
+        if (e.Exception.InnerException is not null)
+        {
+            System.Diagnostics.Debug.WriteLine($"Inner exception: {e.Exception.InnerException}");
+        }
     }
 
     /// <inheritdoc/>

--- a/src/JellyBox/AppServices.cs
+++ b/src/JellyBox/AppServices.cs
@@ -71,6 +71,8 @@ internal sealed class AppServices
         serviceCollection.AddTransient<LibraryViewModel>();
         serviceCollection.AddTransient<LoginViewModel>();
         serviceCollection.AddTransient<MainPageViewModel>();
+        serviceCollection.AddTransient<SearchViewModel>();
+        serviceCollection.AddTransient<ShellSearchViewModel>();
         serviceCollection.AddTransient<ServerSelectionViewModel>();
         serviceCollection.AddTransient<VideoViewModel>();
         serviceCollection.AddTransient<WebVideoViewModel>();

--- a/src/JellyBox/Glyphs.cs
+++ b/src/JellyBox/Glyphs.cs
@@ -7,6 +7,7 @@ internal static class Glyphs
 {
     // Navigation
     public const string Home = "\uE80F";
+    public const string Search = "\uE721";
     public const string Library = "\uE8F1";
     public const string Switch = "\uE895";
     public const string SignOut = "\uE8BB";

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -24,7 +24,6 @@
                 MaxWidth="720"
                 HorizontalAlignment="Stretch"
                 PlaceholderText="Search movies and TV shows"
-                TextMemberPath="DisplayText"
                 Style="{StaticResource SearchAutoSuggestBox}"
                 ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
                 TextChanged="SearchBox_TextChanged"

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -2,13 +2,61 @@
     x:Class="JellyBox.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:JellyBox.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{StaticResource BackgroundBase}">
 
     <Grid XYFocusKeyboardNavigation="Enabled">
-        <Frame x:Name="ContentFrame" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid
+            Grid.Row="0"
+            Padding="48,20,48,12"
+            Background="{StaticResource BackgroundBase}"
+            XYFocusKeyboardNavigation="Enabled">
+            <AutoSuggestBox
+                x:Name="SearchBox"
+                MaxWidth="720"
+                HorizontalAlignment="Stretch"
+                PlaceholderText="Search movies and TV shows"
+                QueryIcon="Find"
+                Style="{StaticResource SearchAutoSuggestBox}"
+                Text="{x:Bind ViewModel.Search.Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
+                QuerySubmitted="SearchBox_QuerySubmitted"
+                SuggestionChosen="SearchBox_SuggestionChosen"
+                XYFocusKeyboardNavigation="Enabled">
+                <AutoSuggestBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:SearchSuggestion">
+                        <StackPanel Orientation="Horizontal" Spacing="12" Padding="4,10">
+                            <FontIcon
+                                FontFamily="{StaticResource SegoeIcons}"
+                                Glyph="&#xE721;"
+                                FontSize="16"
+                                Foreground="{StaticResource TextMuted}"
+                                VerticalAlignment="Center" />
+                            <StackPanel Spacing="2" VerticalAlignment="Center">
+                                <TextBlock
+                                    Text="{x:Bind DisplayText}"
+                                    FontSize="{StaticResource FontS}"
+                                    Foreground="{StaticResource TextPrimary}" />
+                                <TextBlock
+                                    Text="{x:Bind SecondaryText}"
+                                    FontSize="{StaticResource FontXS}"
+                                    Foreground="{StaticResource TextMuted}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+            </AutoSuggestBox>
+        </Grid>
+
+        <Frame x:Name="ContentFrame" Grid.Row="1" />
 
         <Grid
             x:Name="NavigationOverlay"

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -24,13 +24,16 @@
                 MaxWidth="720"
                 HorizontalAlignment="Stretch"
                 PlaceholderText="Search movies and TV shows"
-                QueryIcon="Find"
+                TextMemberPath="DisplayText"
                 Style="{StaticResource SearchAutoSuggestBox}"
-                Text="{x:Bind ViewModel.Search.Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
+                TextChanged="SearchBox_TextChanged"
                 QuerySubmitted="SearchBox_QuerySubmitted"
                 SuggestionChosen="SearchBox_SuggestionChosen"
                 XYFocusKeyboardNavigation="Enabled">
+                <AutoSuggestBox.QueryIcon>
+                    <SymbolIcon Symbol="Find" />
+                </AutoSuggestBox.QueryIcon>
                 <AutoSuggestBox.ItemTemplate>
                     <DataTemplate x:DataType="models:SearchSuggestion">
                         <StackPanel Orientation="Horizontal" Spacing="12" Padding="4,10">
@@ -60,6 +63,8 @@
 
         <Grid
             x:Name="NavigationOverlay"
+            Grid.Row="0"
+            Grid.RowSpan="2"
             Visibility="Collapsed"
             XYFocusKeyboardNavigation="Enabled">
 

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,6 +1,5 @@
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -22,8 +21,6 @@ internal sealed partial class MainPage : Page
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
-
-        KeyDown += OnKeyDown;
 
         SlideInAnimation.Completed += SlideInCompleted;
 
@@ -112,88 +109,6 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
-    }
-
-    /// <summary>
-    /// Keyboard and gamepad input handling.
-    /// Only handles commands and nav-menu-specific logic.
-    /// Directional focus movement is handled by XYFocusKeyboardNavigation in XAML.
-    /// </summary>
-    private void OnKeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        // Don't intercept keys when a text input control has focus
-        if (FocusManager.GetFocusedElement() is TextBox or PasswordBox)
-        {
-            return;
-        }
-
-        switch (e.Key)
-        {
-            // Back gesture - close navigation if open
-            case VirtualKey.Back:
-            case VirtualKey.GamepadB:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Toggle navigation menu
-            case VirtualKey.GamepadMenu:
-            case VirtualKey.GamepadView:
-            case VirtualKey.M:
-            {
-                ViewModel.ToggleNavigationCommand.Execute(null);
-                e.Handled = true;
-                break;
-            }
-
-            // Close navigation menu
-            case VirtualKey.Escape:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Right closes nav menu when open
-            case VirtualKey.Right:
-            case VirtualKey.GamepadDPadRight:
-            case VirtualKey.GamepadLeftThumbstickRight:
-            case VirtualKey.NavigationRight:
-            {
-                if (ViewModel.IsMenuOpen)
-                {
-                    ViewModel.CloseNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-
-            // Left at edge opens nav menu
-            case VirtualKey.Left:
-            case VirtualKey.GamepadDPadLeft:
-            case VirtualKey.GamepadLeftThumbstickLeft:
-            case VirtualKey.NavigationLeft:
-            {
-                if (!ViewModel.IsMenuOpen && !FocusManager.TryMoveFocus(FocusNavigationDirection.Left))
-                {
-                    ViewModel.OpenNavigationCommand.Execute(null);
-                    e.Handled = true;
-                }
-
-                break;
-            }
-        }
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using JellyBox.Models;
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,7 @@ internal sealed partial class MainPage : Page
 
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<MainPageViewModel>();
         ViewModel.IsMenuOpenChanged += OnIsMenuOpenChanged;
+        ViewModel.Search.PropertyChanged += OnSearchPropertyChanged;
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
@@ -34,6 +36,7 @@ internal sealed partial class MainPage : Page
         Unloaded += (sender, e) =>
         {
             ContentFrame.Navigated -= ContentFrameNavigated;
+            ViewModel.Search.PropertyChanged -= OnSearchPropertyChanged;
         };
     }
 
@@ -110,6 +113,23 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
+    }
+
+    private void OnSearchPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ShellSearchViewModel.Query)
+            && SearchBox.Text != ViewModel.Search.Query)
+        {
+            SearchBox.Text = ViewModel.Search.Query;
+        }
+    }
+
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+        {
+            ViewModel.Search.Query = sender.Text ?? string.Empty;
+        }
     }
 
     private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,3 +1,4 @@
+using JellyBox.Models;
 using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.UI.Core;
@@ -109,6 +110,25 @@ internal sealed partial class MainPage : Page
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
+    }
+
+    private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        if (args.ChosenSuggestion is SearchSuggestion suggestion)
+        {
+            ViewModel.Search.SelectSuggestion(suggestion);
+            return;
+        }
+
+        ViewModel.Search.SubmitQuery(args.QueryText);
+    }
+
+    private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        if (args.SelectedItem is SearchSuggestion suggestion)
+        {
+            ViewModel.Search.SelectSuggestion(suggestion);
+        }
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -14,6 +14,7 @@ internal sealed partial class MainPage : Page
 {
     private FrameworkElement? _lastFocusedElement;
     private bool _ignoreNextQuerySubmitted;
+    private bool _suppressSearchTextSync;
 
     public MainPage()
     {
@@ -118,11 +119,14 @@ internal sealed partial class MainPage : Page
 
     private void OnSearchPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(ShellSearchViewModel.Query)
-            && SearchBox.Text != ViewModel.Search.Query)
+        if (_suppressSearchTextSync
+            || e.PropertyName is not nameof(ShellSearchViewModel.Query)
+            || SearchBox.Text == ViewModel.Search.Query)
         {
-            SearchBox.Text = ViewModel.Search.Query;
+            return;
         }
+
+        SearchBox.Text = ViewModel.Search.Query;
     }
 
     private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
@@ -143,7 +147,7 @@ internal sealed partial class MainPage : Page
 
         if (args.ChosenSuggestion is SearchSuggestion suggestion)
         {
-            ViewModel.Search.OpenSuggestion(suggestion);
+            OpenSearchSuggestion(suggestion);
             return;
         }
 
@@ -154,9 +158,30 @@ internal sealed partial class MainPage : Page
     {
         if (args.SelectedItem is SearchSuggestion suggestion)
         {
-            _ignoreNextQuerySubmitted = true;
-            ViewModel.Search.OpenSuggestion(suggestion);
+            OpenSearchSuggestion(suggestion);
         }
+    }
+
+    private void OpenSearchSuggestion(SearchSuggestion suggestion)
+    {
+        _ignoreNextQuerySubmitted = true;
+        ViewModel.Search.PrepareSuggestionNavigation();
+        ViewModel.Search.ClearSuggestions();
+
+        _ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+        {
+            _suppressSearchTextSync = true;
+            try
+            {
+                ViewModel.Search.SetQueryText(suggestion.DisplayText);
+                SearchBox.Text = suggestion.DisplayText;
+                ViewModel.Search.NavigateToItem(suggestion.ItemId);
+            }
+            finally
+            {
+                _suppressSearchTextSync = false;
+            }
+        });
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -13,6 +13,7 @@ namespace JellyBox;
 internal sealed partial class MainPage : Page
 {
     private FrameworkElement? _lastFocusedElement;
+    private bool _ignoreNextQuerySubmitted;
 
     public MainPage()
     {
@@ -134,9 +135,15 @@ internal sealed partial class MainPage : Page
 
     private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
     {
+        if (_ignoreNextQuerySubmitted)
+        {
+            _ignoreNextQuerySubmitted = false;
+            return;
+        }
+
         if (args.ChosenSuggestion is SearchSuggestion suggestion)
         {
-            ViewModel.Search.SelectSuggestion(suggestion);
+            ViewModel.Search.OpenSuggestion(suggestion);
             return;
         }
 
@@ -147,7 +154,8 @@ internal sealed partial class MainPage : Page
     {
         if (args.SelectedItem is SearchSuggestion suggestion)
         {
-            ViewModel.Search.SelectSuggestion(suggestion);
+            _ignoreNextQuerySubmitted = true;
+            ViewModel.Search.OpenSuggestion(suggestion);
         }
     }
 

--- a/src/JellyBox/Models/CardFactory.cs
+++ b/src/JellyBox/Models/CardFactory.cs
@@ -68,7 +68,7 @@ internal sealed class CardFactory
             ImageWidth = imageWidth,
             ImageHeight = imageHeight,
             Image = image,
-            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item.Id!.Value)),
+            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item)),
             IsFavorite = item.UserData?.IsFavorite ?? false,
             IsPlayed = item.UserData?.Played ?? false,
             PlayedPercentage = item.UserData?.PlayedPercentage ?? 0,

--- a/src/JellyBox/Models/CardFactory.cs
+++ b/src/JellyBox/Models/CardFactory.cs
@@ -68,7 +68,7 @@ internal sealed class CardFactory
             ImageWidth = imageWidth,
             ImageHeight = imageHeight,
             Image = image,
-            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item)),
+            NavigateCommand = new RelayCommand(() => _navigationManager.NavigateToItem(item.Id!.Value)),
             IsFavorite = item.UserData?.IsFavorite ?? false,
             IsPlayed = item.UserData?.Played ?? false,
             PlayedPercentage = item.UserData?.PlayedPercentage ?? 0,

--- a/src/JellyBox/Models/SearchSuggestion.cs
+++ b/src/JellyBox/Models/SearchSuggestion.cs
@@ -1,0 +1,3 @@
+namespace JellyBox.Models;
+
+internal sealed record SearchSuggestion(string DisplayText, string? SecondaryText, Guid ItemId);

--- a/src/JellyBox/Resources/Styles.xaml
+++ b/src/JellyBox/Resources/Styles.xaml
@@ -1011,11 +1011,7 @@
     <Style x:Key="SearchAutoSuggestBox" TargetType="AutoSuggestBox">
         <Setter Property="MinHeight" Value="48" />
         <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
-        <Setter Property="Background" Value="{StaticResource BackgroundElevated}" />
-        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtle}" />
-        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontSize" Value="{StaticResource FontM}" />
-        <Setter Property="Padding" Value="12,10" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualPrimaryBrush" Value="{StaticResource FocusBorder}" />
         <Setter Property="FocusVisualSecondaryBrush" Value="Transparent" />

--- a/src/JellyBox/Resources/Styles.xaml
+++ b/src/JellyBox/Resources/Styles.xaml
@@ -1008,6 +1008,20 @@
         </Setter>
     </Style>
 
+    <Style x:Key="SearchAutoSuggestBox" TargetType="AutoSuggestBox">
+        <Setter Property="MinHeight" Value="48" />
+        <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
+        <Setter Property="Background" Value="{StaticResource BackgroundElevated}" />
+        <Setter Property="BorderBrush" Value="{StaticResource BorderSubtle}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FontSize" Value="{StaticResource FontM}" />
+        <Setter Property="Padding" Value="12,10" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="FocusVisualPrimaryBrush" Value="{StaticResource FocusBorder}" />
+        <Setter Property="FocusVisualSecondaryBrush" Value="Transparent" />
+        <Setter Property="FocusVisualPrimaryThickness" Value="3" />
+    </Style>
+
     <Style x:Key="PrimaryTextBox"  TargetType="TextBox">
         <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
         <Setter Property="MinHeight" Value="40" />

--- a/src/JellyBox/Resources/TransportControlsStyles.xaml
+++ b/src/JellyBox/Resources/TransportControlsStyles.xaml
@@ -115,7 +115,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Rewind"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=RewindCommand}"
-                                                      ToolTipService.ToolTip="Rewind 10 seconds (LB)"
+                                                      ToolTipService.ToolTip="Rewind 10 seconds (LB / D-pad left)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon Glyph="&#xED3C;" FontFamily="Segoe MDL2 Assets" />
@@ -127,7 +127,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Play"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PlayPauseCommand}"
-                                                      ToolTipService.ToolTip="Play/Pause (Space)"
+                                                      ToolTipService.ToolTip="Play/Pause (A / Menu / Space)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon x:Name="CustomPlayPauseIcon" Glyph="&#xE768;" FontFamily="Segoe MDL2 Assets" />
@@ -139,7 +139,7 @@
                                                       Style="{StaticResource TransportButtonStyle}"
                                                       Label="Fast Forward"
                                                       Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FastForwardCommand}"
-                                                      ToolTipService.ToolTip="Fast forward 30 seconds (RB)"
+                                                      ToolTipService.ToolTip="Fast forward 30 seconds (RB / D-pad right)"
                                                       XYFocusKeyboardNavigation="Enabled">
                                             <AppBarButton.Icon>
                                                 <FontIcon Glyph="&#xED3D;" FontFamily="Segoe MDL2 Assets" />
@@ -172,7 +172,7 @@
                                         <Button x:Name="CustomVolumeButton"
                                                 Style="{StaticResource TransportIconButtonStyle}"
                                                 Command="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ToggleMuteCommand}"
-                                                ToolTipService.ToolTip="Toggle mute (M)"
+                                                ToolTipService.ToolTip="Toggle mute (X / M)"
                                                 XYFocusKeyboardNavigation="Enabled">
                                             <FontIcon x:Name="CustomVolumeIcon" Glyph="&#xE767;" FontFamily="Segoe MDL2 Assets" />
                                             <Button.Flyout>

--- a/src/JellyBox/Services/CollectionNavigation.cs
+++ b/src/JellyBox/Services/CollectionNavigation.cs
@@ -1,0 +1,58 @@
+using JellyBox.Views;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.Services;
+
+internal static class CollectionNavigation
+{
+    internal static bool TryCreateLibraryParameters(BaseItemDto item, out Library.Parameters parameters)
+    {
+        parameters = default!;
+
+        if (item.Type != BaseItemDto_Type.CollectionFolder
+            || !item.Id.HasValue
+            || !TryMapCollectionType(item.CollectionType, out BaseItemKind itemKind))
+        {
+            return false;
+        }
+
+        parameters = new Library.Parameters(
+            item.Id.Value,
+            itemKind,
+            item.Name ?? GetDefaultTitle(item.CollectionType));
+
+        return true;
+    }
+
+    private static bool TryMapCollectionType(BaseItemDto_CollectionType? collectionType, out BaseItemKind itemKind)
+    {
+        itemKind = default;
+
+        switch (collectionType)
+        {
+            case BaseItemDto_CollectionType.Movies:
+                itemKind = BaseItemKind.Movie;
+                return true;
+            case BaseItemDto_CollectionType.Tvshows:
+                itemKind = BaseItemKind.Series;
+                return true;
+            case BaseItemDto_CollectionType.Boxsets:
+                itemKind = BaseItemKind.BoxSet;
+                return true;
+            case BaseItemDto_CollectionType.Books:
+                itemKind = BaseItemKind.Book;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static string GetDefaultTitle(BaseItemDto_CollectionType? collectionType) => collectionType switch
+    {
+        BaseItemDto_CollectionType.Movies => "Movies",
+        BaseItemDto_CollectionType.Tvshows => "TV Shows",
+        BaseItemDto_CollectionType.Boxsets => "Collections",
+        BaseItemDto_CollectionType.Books => "Books",
+        _ => "Library",
+    };
+}

--- a/src/JellyBox/Services/GamepadInput.cs
+++ b/src/JellyBox/Services/GamepadInput.cs
@@ -10,7 +10,7 @@ namespace JellyBox.Services;
 internal static class GamepadInput
 {
     public static bool IsTextInputFocused()
-        => FocusManager.GetFocusedElement() is TextBox or PasswordBox;
+        => FocusManager.GetFocusedElement() is TextBox or PasswordBox or AutoSuggestBox;
 
     public static bool IsAcceptKey(VirtualKey key)
         => key is VirtualKey.Enter or VirtualKey.GamepadA or VirtualKey.Space;

--- a/src/JellyBox/Services/GamepadInput.cs
+++ b/src/JellyBox/Services/GamepadInput.cs
@@ -1,0 +1,55 @@
+using Windows.System;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace JellyBox.Services;
+
+/// <summary>
+/// Shared Xbox / gamepad virtual-key helpers for consistent controller input across the app.
+/// </summary>
+internal static class GamepadInput
+{
+    public static bool IsTextInputFocused()
+        => FocusManager.GetFocusedElement() is TextBox or PasswordBox;
+
+    public static bool IsAcceptKey(VirtualKey key)
+        => key is VirtualKey.Enter or VirtualKey.GamepadA or VirtualKey.Space;
+
+    public static bool IsBackKey(VirtualKey key)
+        => key is VirtualKey.Back or VirtualKey.Escape or VirtualKey.GamepadB or VirtualKey.GoBack;
+
+    public static bool IsMenuToggleKey(VirtualKey key)
+        => key is VirtualKey.GamepadMenu or VirtualKey.GamepadView or VirtualKey.M;
+
+    public static bool IsNavigateLeftKey(VirtualKey key)
+        => key is VirtualKey.Left
+            or VirtualKey.GamepadDPadLeft
+            or VirtualKey.GamepadLeftThumbstickLeft
+            or VirtualKey.NavigationLeft;
+
+    public static bool IsNavigateRightKey(VirtualKey key)
+        => key is VirtualKey.Right
+            or VirtualKey.GamepadDPadRight
+            or VirtualKey.GamepadLeftThumbstickRight
+            or VirtualKey.NavigationRight;
+
+    public static bool IsVolumeUpKey(VirtualKey key)
+        => key is VirtualKey.Up
+            or VirtualKey.GamepadDPadUp
+            or VirtualKey.GamepadLeftThumbstickUp;
+
+    public static bool IsVolumeDownKey(VirtualKey key)
+        => key is VirtualKey.Down
+            or VirtualKey.GamepadDPadDown
+            or VirtualKey.GamepadLeftThumbstickDown;
+
+    public static bool IsSeekBackwardKey(VirtualKey key)
+        => key is VirtualKey.Left
+            or VirtualKey.GamepadDPadLeft
+            or VirtualKey.GamepadLeftThumbstickLeft;
+
+    public static bool IsSeekForwardKey(VirtualKey key)
+        => key is VirtualKey.Right
+            or VirtualKey.GamepadDPadRight
+            or VirtualKey.GamepadLeftThumbstickRight;
+}

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -18,6 +18,21 @@ internal sealed class NavigationManager
 
     public event Action? MenuOpenRequested;
 
+    /// <summary>
+    /// Opens the shell navigation menu.
+    /// </summary>
+    public Action? OpenNavigationMenu { get; set; }
+
+    /// <summary>
+    /// Toggles the shell navigation menu.
+    /// </summary>
+    public Action? ToggleNavigationMenu { get; set; }
+
+    /// <summary>
+    /// Closes the shell navigation menu when open. Returns true if the menu was closed.
+    /// </summary>
+    public Func<bool>? TryCloseNavigationMenu { get; set; }
+
     private Frame _appFrame = null!; // TODO
 
     private Frame? _contentFrame;
@@ -45,6 +60,7 @@ internal sealed class NavigationManager
 
         SystemNavigationManager.GetForCurrentView().BackRequested += BackRequested;
         Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += AcceleratorKeyActivated;
+        Window.Current.CoreWindow.KeyDown += CoreWindowKeyDown;
         Window.Current.CoreWindow.PointerPressed += PointerPressed;
     }
 
@@ -250,9 +266,18 @@ internal sealed class NavigationManager
         bool onlyAlt = menuKey && !controlKey && !shiftKey;
         VirtualKey virtualKey = e.VirtualKey;
 
-        if ((virtualKey is VirtualKey.GoBack && noModifiers)
-            || (virtualKey is VirtualKey.Left && onlyAlt)
-            || (virtualKey is VirtualKey.Back && noModifiers))
+        if (GamepadInput.IsBackKey(virtualKey) && noModifiers)
+        {
+            if (TryCloseNavigationMenu?.Invoke() == true)
+            {
+                e.Handled = true;
+            }
+            else
+            {
+                e.Handled = GoBack();
+            }
+        }
+        else if (virtualKey is VirtualKey.Left && onlyAlt)
         {
             e.Handled = GoBack();
         }
@@ -260,6 +285,51 @@ internal sealed class NavigationManager
             || (virtualKey is VirtualKey.Right && onlyAlt))
         {
             e.Handled = GoForward();
+        }
+    }
+
+    /// <summary>
+    /// Global gamepad and keyboard shortcuts for the main app shell (home, library, details).
+    /// Full-screen pages such as video playback register their own handlers.
+    /// </summary>
+    private void CoreWindowKeyDown(CoreWindow sender, KeyEventArgs e)
+    {
+        if (_contentFrame is null || GamepadInput.IsTextInputFocused())
+        {
+            return;
+        }
+
+        VirtualKey key = e.VirtualKey;
+
+        if (GamepadInput.IsMenuToggleKey(key))
+        {
+            ToggleNavigationMenu?.Invoke();
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsBackKey(key) && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (key is VirtualKey.Escape && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsNavigateRightKey(key) && TryCloseNavigationMenu?.Invoke() == true)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        if (GamepadInput.IsNavigateLeftKey(key) && !FocusManager.TryMoveFocus(FocusNavigationDirection.Left))
+        {
+            OpenNavigationMenu?.Invoke();
+            e.Handled = true;
         }
     }
 

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using JellyBox.Views;
+using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Windows.ApplicationModel;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Input;
@@ -43,6 +46,13 @@ internal sealed class NavigationManager
     private object? _currentAppParameter;
 
     private object? _currentContentParameter;
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+
+    public NavigationManager(JellyfinApiClient jellyfinApiClient)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+    }
 
     /// <summary>
     /// Gets the item associated with the current page.
@@ -105,40 +115,43 @@ internal sealed class NavigationManager
         NavigateContentFrame<Search>(new Search.Parameters(query));
     }
 
-    public void NavigateToItem(Guid itemId)
-    {
-        CurrentItem = itemId;
-        NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
-    }
+    public void NavigateToItem(Guid itemId) => _ = NavigateToItemAsync(itemId);
 
-    public void NavigateToItem(BaseItemDto item)
+    public void NavigateToItem(BaseItemDto item) => NavigateToResolvedItem(item);
+
+    private async Task NavigateToItemAsync(Guid itemId)
     {
-        Guid itemId = item.Id!.Value;
-        if (item.Type == BaseItemDto_Type.CollectionFolder)
+        try
         {
-            switch (item.CollectionType)
+            BaseItemDto? item = await _jellyfinApiClient.Items[itemId].GetAsync();
+            if (item is null)
             {
-                case BaseItemDto_CollectionType.Movies:
-                {
-                    CurrentItem = itemId;
-                    NavigateContentFrame<Library>(new Library.Parameters(itemId, BaseItemKind.Movie, item.Name ?? "Movies"));
-                    return;
-                }
-                case BaseItemDto_CollectionType.Tvshows:
-                {
-                    CurrentItem = itemId;
-                    NavigateContentFrame<Library>(new Library.Parameters(itemId, BaseItemKind.Series, item.Name ?? "TV Shows"));
-                    return;
-                }
+                return;
             }
 
-            // TODO: Some kind of error message. Or genericize the collection view.
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+                CoreDispatcherPriority.Normal,
+                () => NavigateToResolvedItem(item));
         }
-        else
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in NavigationManager.NavigateToItemAsync: {ex}");
+        }
+    }
+
+    private void NavigateToResolvedItem(BaseItemDto item)
+    {
+        Guid itemId = item.Id!.Value;
+
+        if (CollectionNavigation.TryCreateLibraryParameters(item, out Library.Parameters libraryParameters))
         {
             CurrentItem = itemId;
-            NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
+            NavigateContentFrame<Library>(libraryParameters);
+            return;
         }
+
+        CurrentItem = itemId;
+        NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
     }
 
     public void NavigateToPerson(BaseItemPerson person)

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -16,6 +16,9 @@ internal sealed class NavigationManager
     // Fake item id used to identify the home page
     public static readonly Guid HomeId = new Guid("CDF95D47-90C2-4057-B12C-BA81C34F2CB9");
 
+    // Fake item id used to identify the search page
+    public static readonly Guid SearchId = new Guid("A4B8C2E1-6F3D-4A91-9B7E-2D5C8F1A3E64");
+
     public event Action? MenuOpenRequested;
 
     /// <summary>
@@ -94,6 +97,18 @@ internal sealed class NavigationManager
     {
         CurrentItem = HomeId;
         NavigateContentFrame<Home>();
+    }
+
+    public void NavigateToSearch(string query)
+    {
+        CurrentItem = SearchId;
+        NavigateContentFrame<Search>(new Search.Parameters(query));
+    }
+
+    public void NavigateToItem(Guid itemId)
+    {
+        CurrentItem = itemId;
+        NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
     }
 
     public void NavigateToItem(BaseItemDto item)

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -144,9 +144,12 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         _cardFactory = cardFactory;
     }
 
+    public void CancelLoading() => Interlocked.Increment(ref _loadVersion);
+
     internal async void HandleParameters(ItemDetails.Parameters parameters)
     {
         int version = Interlocked.Increment(ref _loadVersion);
+        ResetDisplayState();
 
         try
         {
@@ -213,12 +216,20 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
             if (Item.MediaSources is not null && Item.MediaSources.Count > 0)
             {
-                SourceContainers = new ObservableCollection<MediaSourceInfoWrapper>(Item.MediaSources.Select(s => new MediaSourceInfoWrapper(s.Name!, s)));
+                SourceContainers = new ObservableCollection<MediaSourceInfoWrapper>(
+                    Item.MediaSources.Select(s => new MediaSourceInfoWrapper(s.Name ?? "Unknown", s)));
                 HasMultipleSources = SourceContainers.Count > 1;
                 HasSingleSource = SourceContainers.Count == 1;
 
                 // This will trigger OnSelectedSourceContainerChanged, which populates the video, audio, and subtitle drop-downs.
                 SelectedSourceContainer = SourceContainers[0];
+            }
+            else
+            {
+                SourceContainers = null;
+                HasMultipleSources = false;
+                HasSingleSource = false;
+                SelectedSourceContainer = null;
             }
 
             TagLine = Item.Taglines is not null && Item.Taglines.Count > 0 ? Item.Taglines[0] : null;
@@ -267,17 +278,52 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     partial void OnSelectedSourceContainerChanged(MediaSourceInfoWrapper? value)
     {
-        if (value is not null)
+        if (value is null)
+        {
+            return;
+        }
+
+        try
         {
             DetermineVideoOptions(value.Value);
             DetermineAudioOptions(value.Value);
             DetermineSubtitleOptions(value.Value);
         }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error in OnSelectedSourceContainerChanged: {ex}");
+        }
+    }
+
+    private void ResetDisplayState()
+    {
+        SourceContainers = null;
+        HasMultipleSources = false;
+        HasSingleSource = false;
+        SelectedSourceContainer = null;
+        VideoStreams = null;
+        SelectedVideoStream = null;
+        AudioStreams = null;
+        SelectedAudioStream = null;
+        HasMultipleAudioStreams = false;
+        HasSingleAudioStream = false;
+        SubtitleStreams = null;
+        SelectedSubtitleStream = null;
+        HasMultipleSubtitleStreams = false;
+        HasSingleSubtitleStream = false;
+        Sections = null;
     }
 
     private void DetermineVideoOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> videoStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            VideoStreams = [];
+            SelectedVideoStream = null;
+            return;
+        }
+
+        List<MediaStream> videoStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Video)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -309,7 +355,16 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     private void DetermineAudioOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> audioStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            AudioStreams = [];
+            HasMultipleAudioStreams = false;
+            HasSingleAudioStream = false;
+            SelectedAudioStream = null;
+            return;
+        }
+
+        List<MediaStream> audioStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Audio)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -337,7 +392,16 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     private void DetermineSubtitleOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> subtitleStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            SubtitleStreams = [MediaStreamOption.SubtitlesOff];
+            HasMultipleSubtitleStreams = false;
+            HasSingleSubtitleStream = true;
+            SelectedSubtitleStream = MediaStreamOption.SubtitlesOff;
+            return;
+        }
+
+        List<MediaStream> subtitleStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Subtitle)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -28,6 +28,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
     private readonly JellyfinImageResolver _imageResolver;
     private readonly NavigationManager _navigationManager;
     private readonly CardFactory _cardFactory;
+    private int _loadVersion;
 
     [ObservableProperty]
     public partial BaseItemDto? Item { get; set; }
@@ -145,11 +146,24 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     internal async void HandleParameters(ItemDetails.Parameters parameters)
     {
+        int version = Interlocked.Increment(ref _loadVersion);
+
         try
         {
-            Item = await _jellyfinApiClient.Items[parameters.ItemId].GetAsync();
+            BaseItemDto? item = await _jellyfinApiClient.Items[parameters.ItemId].GetAsync();
+            if (version != _loadVersion)
+            {
+                return;
+            }
 
-            Name = Item!.Name;
+            if (item is null)
+            {
+                return;
+            }
+
+            Item = item;
+
+            Name = Item.Name;
 
             // Disable backdrop for Person and Book types because they only have primary images
             if (Item.Type is not BaseItemDto_Type.Person and not BaseItemDto_Type.Book)
@@ -232,6 +246,11 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             foreach (Task<Section?> sectionTask in sectionTasks)
             {
                 Section? section = await sectionTask;
+                if (version != _loadVersion)
+                {
+                    return;
+                }
+
                 if (section is not null)
                 {
                     sections.Add(section);
@@ -511,7 +530,18 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             return;
         }
 
-        IsPlayed = Item.UserData!.Played.GetValueOrDefault();
+        if (Item.UserData is null)
+        {
+            IsPlayed = false;
+            IsFavorite = false;
+            CanResume = false;
+            PlayButtonText = "Play";
+            PlayButtonGlyph = Glyphs.Play;
+            ResumePositionText = null;
+            return;
+        }
+
+        IsPlayed = Item.UserData.Played.GetValueOrDefault();
         IsFavorite = Item.UserData.IsFavorite.GetValueOrDefault();
 
         long positionTicks = Item.UserData.PlaybackPositionTicks.GetValueOrDefault();

--- a/src/JellyBox/ViewModels/MainPageViewModel.cs
+++ b/src/JellyBox/ViewModels/MainPageViewModel.cs
@@ -26,14 +26,18 @@ internal sealed partial class MainPageViewModel : ObservableObject
     [ObservableProperty]
     public partial ObservableCollection<NavigationViewItemBase>? NavigationItems { get; set; }
 
+    public ShellSearchViewModel Search { get; }
+
     public MainPageViewModel(
         AppSettings appSettings,
         JellyfinApiClient jellyfinApiClient,
-        NavigationManager navigationManager)
+        NavigationManager navigationManager,
+        ShellSearchViewModel shellSearchViewModel)
     {
         _appSettings = appSettings;
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
+        Search = shellSearchViewModel;
         _navigationManager.MenuOpenRequested += () => IsMenuOpen = true;
         _navigationManager.OpenNavigationMenu = () => IsMenuOpen = true;
         _navigationManager.ToggleNavigationMenu = () => IsMenuOpen = !IsMenuOpen;

--- a/src/JellyBox/ViewModels/MainPageViewModel.cs
+++ b/src/JellyBox/ViewModels/MainPageViewModel.cs
@@ -35,6 +35,18 @@ internal sealed partial class MainPageViewModel : ObservableObject
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
         _navigationManager.MenuOpenRequested += () => IsMenuOpen = true;
+        _navigationManager.OpenNavigationMenu = () => IsMenuOpen = true;
+        _navigationManager.ToggleNavigationMenu = () => IsMenuOpen = !IsMenuOpen;
+        _navigationManager.TryCloseNavigationMenu = () =>
+        {
+            if (!IsMenuOpen)
+            {
+                return false;
+            }
+
+            IsMenuOpen = false;
+            return true;
+        };
     }
 
     [RelayCommand]

--- a/src/JellyBox/ViewModels/SearchViewModel.cs
+++ b/src/JellyBox/ViewModels/SearchViewModel.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Views;
+using Jellyfin.Sdk;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.ViewModels;
+
+#pragma warning disable CA1812
+internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewModel
+#pragma warning restore CA1812
+{
+    private const int ResultLimit = 100;
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly CardFactory _cardFactory;
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial string Query { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string ResultsTitle { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string? ResultsSubtitle { get; private set; }
+
+    [ObservableProperty]
+    public partial bool ShowEmptyState { get; private set; }
+
+    [ObservableProperty]
+    public partial IReadOnlyList<Card>? Items { get; private set; }
+
+    public SearchViewModel(
+        JellyfinApiClient jellyfinApiClient,
+        CardFactory cardFactory)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+        _cardFactory = cardFactory;
+    }
+
+    public void HandleParameters(Search.Parameters parameters)
+    {
+        Query = parameters.Query.Trim();
+        ResultsTitle = $"Results for \"{Query}\"";
+        Items = null;
+        ShowEmptyState = false;
+        ResultsSubtitle = null;
+        _ = LoadResultsAsync();
+    }
+
+    private async Task LoadResultsAsync()
+    {
+        IsLoading = true;
+
+        try
+        {
+            BaseItemDtoQueryResult? result = await _jellyfinApiClient.Items.GetAsync(parameters =>
+            {
+                parameters.QueryParameters.SearchTerm = Query;
+                parameters.QueryParameters.IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series];
+                parameters.QueryParameters.Recursive = true;
+                parameters.QueryParameters.SortBy = [ItemSortBy.SortName];
+                parameters.QueryParameters.Limit = ResultLimit;
+                parameters.QueryParameters.Fields = [ItemFields.PrimaryImageAspectRatio, ItemFields.MediaSourceCount];
+                parameters.QueryParameters.ImageTypeLimit = 1;
+                parameters.QueryParameters.EnableImageTypes = [ImageType.Primary, ImageType.Backdrop, ImageType.Banner, ImageType.Thumb];
+            });
+
+            if (result?.Items is null || result.Items.Count == 0)
+            {
+                Items = [];
+                ShowEmptyState = true;
+                ResultsSubtitle = "No movies or TV shows matched your search.";
+                return;
+            }
+
+            List<Card> items = new(result.Items.Count);
+            foreach (BaseItemDto item in result.Items)
+            {
+                if (!item.Id.HasValue)
+                {
+                    continue;
+                }
+
+                if (item.Type is not (BaseItemDto_Type.Movie or BaseItemDto_Type.Series))
+                {
+                    continue;
+                }
+
+                items.Add(_cardFactory.CreateFromItem(item, CardShape.Portrait, preferredImageType: null));
+            }
+
+            Items = items;
+            ShowEmptyState = items.Count == 0;
+            ResultsSubtitle = items.Count == 0
+                ? "No movies or TV shows matched your search."
+                : items.Count == 1
+                    ? "1 result"
+                    : $"{items.Count} results";
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in SearchViewModel.LoadResultsAsync: {ex}");
+            Items = [];
+            ShowEmptyState = true;
+            ResultsSubtitle = "Something went wrong while searching. Please try again.";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+}

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -47,8 +47,15 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         _navigationManager.NavigateToSearch(trimmed);
     }
 
-    public void SelectSuggestion(SearchSuggestion suggestion)
-        => _navigationManager.NavigateToItem(suggestion.ItemId);
+    public void OpenSuggestion(SearchSuggestion suggestion)
+    {
+        Interlocked.Increment(ref _searchVersion);
+        ClearSuggestions();
+        Query = suggestion.DisplayText;
+        _navigationManager.NavigateToItem(suggestion.ItemId);
+    }
+
+    public void ClearSuggestions() => ReplaceSuggestions([]);
 
     private async Task UpdateSuggestionsAsync(string query)
     {

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -1,0 +1,131 @@
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Services;
+using Jellyfin.Sdk;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.ViewModels;
+
+#pragma warning disable CA1812
+internal sealed partial class ShellSearchViewModel : ObservableObject
+#pragma warning restore CA1812
+{
+    private const int MinimumQueryLength = 2;
+    private const int SuggestionLimit = 8;
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(350);
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly NavigationManager _navigationManager;
+    private int _searchVersion;
+
+    [ObservableProperty]
+    public partial string Query { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial IReadOnlyList<SearchSuggestion> Suggestions { get; set; } = [];
+
+    public ShellSearchViewModel(
+        JellyfinApiClient jellyfinApiClient,
+        NavigationManager navigationManager)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+        _navigationManager = navigationManager;
+    }
+
+    partial void OnQueryChanged(string value) => _ = UpdateSuggestionsAsync(value);
+
+    public void SubmitQuery(string? query)
+    {
+        string trimmed = (query ?? Query).Trim();
+        if (trimmed.Length < MinimumQueryLength)
+        {
+            return;
+        }
+
+        Query = trimmed;
+        _navigationManager.NavigateToSearch(trimmed);
+    }
+
+    public void SelectSuggestion(SearchSuggestion suggestion)
+        => _navigationManager.NavigateToItem(suggestion.ItemId);
+
+    private async Task UpdateSuggestionsAsync(string query)
+    {
+        int version = Interlocked.Increment(ref _searchVersion);
+
+        string trimmed = query.Trim();
+        if (trimmed.Length < MinimumQueryLength)
+        {
+            Suggestions = [];
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(DebounceDelay);
+
+            if (version != _searchVersion)
+            {
+                return;
+            }
+
+            SearchHintResult? result = await _jellyfinApiClient.Search.Hints.GetAsync(
+                parameters =>
+                {
+                    parameters.QueryParameters.SearchTerm = trimmed;
+                    parameters.QueryParameters.IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series];
+                    parameters.QueryParameters.IncludeMedia = true;
+                    parameters.QueryParameters.Limit = SuggestionLimit;
+                });
+
+            if (version != _searchVersion)
+            {
+                return;
+            }
+
+            if (result?.SearchHints is null)
+            {
+                Suggestions = [];
+                return;
+            }
+
+            List<SearchSuggestion> suggestions = new(result.SearchHints.Count);
+            foreach (SearchHint hint in result.SearchHints)
+            {
+                SearchSuggestion? suggestion = CreateSuggestion(hint);
+                if (suggestion is not null)
+                {
+                    suggestions.Add(suggestion);
+                }
+            }
+
+            Suggestions = suggestions;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in ShellSearchViewModel.UpdateSuggestionsAsync: {ex}");
+            Suggestions = [];
+        }
+    }
+
+    private static SearchSuggestion? CreateSuggestion(SearchHint hint)
+    {
+        if (hint.Type is not (SearchHint_Type.Movie or SearchHint_Type.Series))
+        {
+            return null;
+        }
+
+        if (!hint.Id.HasValue || string.IsNullOrWhiteSpace(hint.Name))
+        {
+            return null;
+        }
+
+        string typeLabel = hint.Type == SearchHint_Type.Movie ? "Movie" : "TV Show";
+        string? secondaryText = hint.ProductionYear.HasValue
+            ? $"{typeLabel} · {hint.ProductionYear.Value}"
+            : typeLabel;
+
+        return new SearchSuggestion(hint.Name, secondaryText, hint.Id.Value);
+    }
+}

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -47,13 +47,13 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         _navigationManager.NavigateToSearch(trimmed);
     }
 
-    public void OpenSuggestion(SearchSuggestion suggestion)
-    {
-        Interlocked.Increment(ref _searchVersion);
-        ClearSuggestions();
-        Query = suggestion.DisplayText;
-        _navigationManager.NavigateToItem(suggestion.ItemId);
-    }
+    public void PrepareSuggestionNavigation()
+        => Interlocked.Increment(ref _searchVersion);
+
+    public void SetQueryText(string query) => Query = query;
+
+    public void NavigateToItem(Guid itemId)
+        => _navigationManager.NavigateToItem(itemId);
 
     public void ClearSuggestions() => ReplaceSuggestions([]);
 

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using JellyBox.Models;
@@ -22,8 +23,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
     [ObservableProperty]
     public partial string Query { get; set; } = string.Empty;
 
-    [ObservableProperty]
-    public partial IReadOnlyList<SearchSuggestion> Suggestions { get; set; } = [];
+    public ObservableCollection<SearchSuggestion> Suggestions { get; } = [];
 
     public ShellSearchViewModel(
         JellyfinApiClient jellyfinApiClient,
@@ -57,7 +57,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         string trimmed = query.Trim();
         if (trimmed.Length < MinimumQueryLength)
         {
-            Suggestions = [];
+            ReplaceSuggestions([]);
             return;
         }
 
@@ -86,7 +86,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
 
             if (result?.SearchHints is null)
             {
-                Suggestions = [];
+                ReplaceSuggestions([]);
                 return;
             }
 
@@ -100,12 +100,21 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
                 }
             }
 
-            Suggestions = suggestions;
+            ReplaceSuggestions(suggestions);
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"Error in ShellSearchViewModel.UpdateSuggestionsAsync: {ex}");
-            Suggestions = [];
+            ReplaceSuggestions([]);
+        }
+    }
+
+    private void ReplaceSuggestions(IEnumerable<SearchSuggestion> suggestions)
+    {
+        Suggestions.Clear();
+        foreach (SearchSuggestion suggestion in suggestions)
+        {
+            Suggestions.Add(suggestion);
         }
     }
 

--- a/src/JellyBox/Views/Home.xaml
+++ b/src/JellyBox/Views/Home.xaml
@@ -20,7 +20,7 @@
                 x:Name="SectionsControl"
                 ItemsSource="{x:Bind ViewModel.Sections, Mode=OneWay}"
                 ItemTemplate="{StaticResource Section}"
-                Margin="0,48,0,48"
+                Margin="0,16,0,48"
                 XYFocusKeyboardNavigation="Enabled">
                 <Interactivity:Interaction.Behaviors>
                     <Behaviors:SectionNavigationBehavior

--- a/src/JellyBox/Views/ItemDetails.xaml
+++ b/src/JellyBox/Views/ItemDetails.xaml
@@ -250,7 +250,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedSourceContainer.Value.Name, Mode=OneWay}"
+                                    Text="{x:Bind GetSourceContainerName(ViewModel.SelectedSourceContainer), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -285,7 +285,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedSourceContainer.Value.Name, Mode=OneWay}"
+                                Text="{x:Bind GetSourceContainerName(ViewModel.SelectedSourceContainer), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>
@@ -312,7 +312,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedAudioStream.DisplayText, Mode=OneWay}"
+                                    Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedAudioStream), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -347,7 +347,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedAudioStream.DisplayText, Mode=OneWay}"
+                                Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedAudioStream), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>
@@ -374,7 +374,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedSubtitleStream.DisplayText, Mode=OneWay}"
+                                    Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedSubtitleStream), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -409,7 +409,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedSubtitleStream.DisplayText, Mode=OneWay}"
+                                Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedSubtitleStream), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>

--- a/src/JellyBox/Views/ItemDetails.xaml
+++ b/src/JellyBox/Views/ItemDetails.xaml
@@ -63,7 +63,7 @@
             VerticalScrollBarVisibility="Hidden"
             BringIntoViewOnFocusChange="False"
             IsTabStop="False">
-            <Grid x:Name="ContentGrid" XYFocusKeyboardNavigation="Enabled" Margin="48,100,48,48">
+            <Grid x:Name="ContentGrid" XYFocusKeyboardNavigation="Enabled" Margin="48,24,48,48">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="380" />
                     <ColumnDefinition Width="*" />

--- a/src/JellyBox/Views/ItemDetails.xaml.cs
+++ b/src/JellyBox/Views/ItemDetails.xaml.cs
@@ -41,6 +41,9 @@ internal sealed partial class ItemDetails : Page
         ViewModel.HandleParameters((Parameters)e.Parameter);
     }
 
+    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        => ViewModel.CancelLoading();
+
     internal sealed record Parameters(Guid ItemId);
 
     #region Initial Focus
@@ -240,6 +243,16 @@ internal sealed partial class ItemDetails : Page
     private Style GetPlayButtonStyle(bool canResume)
 #pragma warning restore CA1822
         => (Style)Application.Current.Resources[canResume ? "SecondaryButton" : "PrimaryButton"];
+
+#pragma warning disable CA1822 // Used by x:Bind
+    private string GetSourceContainerName(MediaSourceInfoWrapper? source)
+#pragma warning restore CA1822
+        => source?.Value?.Name ?? string.Empty;
+
+#pragma warning disable CA1822 // Used by x:Bind
+    private string GetStreamDisplayText(MediaStreamOption? stream)
+#pragma warning restore CA1822
+        => stream?.DisplayText ?? string.Empty;
 
     private bool IsActionButton(object? element)
         => ReferenceEquals(element, ResumeButton)

--- a/src/JellyBox/Views/ItemDetails.xaml.cs
+++ b/src/JellyBox/Views/ItemDetails.xaml.cs
@@ -32,7 +32,14 @@ internal sealed partial class ItemDetails : Page
 
     internal ItemDetailsViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        _hasFocusedInitial = false;
+        _lastNavigationDirection = null;
+        ContentInfoPanel.LayoutUpdated -= ContentInfoPanel_LayoutUpdated;
+        ContentInfoPanel.LayoutUpdated += ContentInfoPanel_LayoutUpdated;
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+    }
 
     internal sealed record Parameters(Guid ItemId);
 

--- a/src/JellyBox/Views/Library.xaml
+++ b/src/JellyBox/Views/Library.xaml
@@ -18,7 +18,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header: Title + Toolbar -->
-        <StackPanel Grid.Row="0" Padding="48,24,48,0">
+        <StackPanel Grid.Row="0" Padding="48,16,48,0">
             <TextBlock
                 Text="{x:Bind ViewModel.Title, Mode=OneWay}"
                 FontSize="{StaticResource FontXL}"

--- a/src/JellyBox/Views/Login.xaml.cs
+++ b/src/JellyBox/Views/Login.xaml.cs
@@ -1,6 +1,6 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
@@ -33,7 +33,7 @@ internal sealed partial class Login : Page
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key is VirtualKey.Enter or VirtualKey.GamepadMenu
+        if (GamepadInput.IsAcceptKey(e.Key)
             && ViewModel.SignInCommand.CanExecute(null))
         {
             ViewModel.SignInCommand.Execute(null);

--- a/src/JellyBox/Views/Search.xaml
+++ b/src/JellyBox/Views/Search.xaml
@@ -1,0 +1,62 @@
+<Page
+    x:Class="JellyBox.Views.Search"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Behaviors="using:JellyBox.Behaviors"
+    xmlns:controls="using:JellyBox.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{StaticResource BackgroundBase}">
+
+    <Grid XYFocusKeyboardNavigation="Enabled">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Padding="48,16,48,8" Spacing="4">
+            <TextBlock
+                Text="{x:Bind ViewModel.ResultsTitle, Mode=OneWay}"
+                FontSize="{StaticResource FontXL}"
+                FontWeight="SemiBold"
+                Foreground="{StaticResource TextPrimary}" />
+            <TextBlock
+                Text="{x:Bind ViewModel.ResultsSubtitle, Mode=OneWay}"
+                FontSize="{StaticResource FontS}"
+                Foreground="{StaticResource TextMuted}" />
+        </StackPanel>
+
+        <GridView
+            Grid.Row="1"
+            Padding="48,8,48,48"
+            ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}"
+            ItemTemplate="{StaticResource Card}"
+            ItemContainerStyle="{StaticResource CardGridViewItemStyle}"
+            SelectionMode="None"
+            IsItemClickEnabled="True"
+            SingleSelectionFollowsFocus="False"
+            TabNavigation="Once"
+            IsTabStop="False"
+            XYFocusKeyboardNavigation="Enabled"
+            ScrollViewer.VerticalScrollBarVisibility="Hidden"
+            ScrollViewer.VerticalScrollMode="Enabled"
+            ScrollViewer.HorizontalScrollMode="Disabled"
+            ScrollViewer.BringIntoViewOnFocusChange="False"
+            Visibility="{x:Bind ViewModel.ShowEmptyState, Mode=OneWay, Converter={StaticResource NegateConverter}}">
+            <Interactivity:Interaction.Behaviors>
+                <Behaviors:FocusFirstItemBehavior />
+                <Behaviors:ListViewBaseCommandBehavior />
+                <Behaviors:ScrollOnFocusBehavior SafeZoneMargin="48" EnableVerticalScroll="True" TrapFocusAtRightEdge="False" TopOffset="100" />
+            </Interactivity:Interaction.Behaviors>
+            <GridView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsWrapGrid Orientation="Horizontal" HorizontalAlignment="Center" />
+                </ItemsPanelTemplate>
+            </GridView.ItemsPanel>
+        </GridView>
+
+        <controls:LoadingOverlay Grid.Row="1" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+    </Grid>
+</Page>

--- a/src/JellyBox/Views/Search.xaml.cs
+++ b/src/JellyBox/Views/Search.xaml.cs
@@ -1,0 +1,22 @@
+using JellyBox.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace JellyBox.Views;
+
+internal sealed partial class Search : Page
+{
+    public Search()
+    {
+        InitializeComponent();
+        ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<SearchViewModel>();
+    }
+
+    internal SearchViewModel ViewModel { get; }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+        => ViewModel.HandleParameters((Parameters)e.Parameter);
+
+    internal sealed record Parameters(string Query);
+}

--- a/src/JellyBox/Views/ServerSelection.xaml.cs
+++ b/src/JellyBox/Views/ServerSelection.xaml.cs
@@ -1,6 +1,6 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
-using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
@@ -20,7 +20,7 @@ internal sealed partial class ServerSelection : Page
 
     private void OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key is VirtualKey.Enter or VirtualKey.GamepadMenu
+        if (GamepadInput.IsAcceptKey(e.Key)
             && ViewModel.ConnectCommand.CanExecute(null))
         {
             ViewModel.ConnectCommand.Execute(null);

--- a/src/JellyBox/Views/Video.xaml.cs
+++ b/src/JellyBox/Views/Video.xaml.cs
@@ -1,4 +1,5 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.System;
@@ -41,8 +42,10 @@ internal sealed partial class Video : Page
         object? focused = FocusManager.GetFocusedElement();
         bool hasControlFocus = focused is Control and not Page;
 
+        VirtualKey key = args.VirtualKey;
+
         // Handle Xbox controller and keyboard shortcuts
-        switch (args.VirtualKey)
+        switch (key)
         {
             // Controller: LB, Keyboard: J - Rewind 10 seconds
             case VirtualKey.GamepadLeftShoulder:
@@ -68,10 +71,14 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Controller: Menu, Keyboard: Space/K - Play/Pause
+            // Controller: A / Menu, Keyboard: Space/K - Play/Pause
+            case VirtualKey.GamepadA:
             case VirtualKey.GamepadMenu:
-                ViewModel.TogglePlayPause();
-                args.Handled = true;
+                if (!hasControlFocus || key is VirtualKey.GamepadMenu)
+                {
+                    ViewModel.TogglePlayPause();
+                    args.Handled = true;
+                }
                 break;
 
             case VirtualKey.Space:
@@ -83,7 +90,8 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Keyboard: M - Toggle mute
+            // Controller: X, Keyboard: M - Toggle mute
+            case VirtualKey.GamepadX:
             case VirtualKey.M:
                 if (!hasControlFocus)
                 {
@@ -92,46 +100,38 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Keyboard: Up/Down arrow - Volume control (when not on a control)
-            case VirtualKey.Up:
+            default:
                 if (!hasControlFocus)
                 {
-                    ViewModel.AdjustVolume(0.1);
-                    args.Handled = true;
+                    if (GamepadInput.IsVolumeUpKey(key))
+                    {
+                        ViewModel.AdjustVolume(0.1);
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsVolumeDownKey(key))
+                    {
+                        ViewModel.AdjustVolume(-0.1);
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsSeekBackwardKey(key))
+                    {
+                        ViewModel.Rewind();
+                        args.Handled = true;
+                    }
+                    else if (GamepadInput.IsSeekForwardKey(key))
+                    {
+                        ViewModel.FastForward();
+                        args.Handled = true;
+                    }
                 }
-                break;
 
-            case VirtualKey.Down:
-                if (!hasControlFocus)
-                {
-                    ViewModel.AdjustVolume(-0.1);
-                    args.Handled = true;
-                }
                 break;
+        }
 
-            // Keyboard: Left/Right arrow - Seek (when not on a control)
-            case VirtualKey.Left:
-                if (!hasControlFocus)
-                {
-                    ViewModel.Rewind();
-                    args.Handled = true;
-                }
-                break;
-
-            case VirtualKey.Right:
-                if (!hasControlFocus)
-                {
-                    ViewModel.FastForward();
-                    args.Handled = true;
-                }
-                break;
-
-            // Keyboard: Escape - Go back
-            case VirtualKey.Escape:
-            case VirtualKey.GamepadB:
-                Frame.GoBack();
-                args.Handled = true;
-                break;
+        if (!args.Handled && GamepadInput.IsBackKey(key))
+        {
+            Frame.GoBack();
+            args.Handled = true;
         }
     }
 

--- a/src/JellyBox/Views/WebVideo.xaml.cs
+++ b/src/JellyBox/Views/WebVideo.xaml.cs
@@ -1,4 +1,7 @@
-﻿using JellyBox.ViewModels;
+﻿using JellyBox.Services;
+using JellyBox.ViewModels;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -15,12 +18,27 @@ internal sealed partial class WebVideo : Page
 
     internal WebVideoViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+        Window.Current.CoreWindow.KeyDown += OnCoreWindowKeyDown;
+    }
 
     protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
     {
+        Window.Current.CoreWindow.KeyDown -= OnCoreWindowKeyDown;
+
         // Dispose of the webview to stop the video
         WebView2.Close();
+    }
+
+    private void OnCoreWindowKeyDown(CoreWindow sender, KeyEventArgs args)
+    {
+        if (GamepadInput.IsBackKey(args.VirtualKey))
+        {
+            Frame.GoBack();
+            args.Handled = true;
+        }
     }
 
     internal sealed record Parameters(Uri VideoUri);


### PR DESCRIPTION
## Summary

Routes Jellyfin collection folders (Movies, TV Shows, Collections, Books) to the `Library` page instead of `ItemDetails`.

> **Review tip:** For the ~96-line incremental diff, use the [fork compare view](https://github.com/CyberoniOntoni/JellyBox/compare/feature/shell-search...feature/collection-navigation) or [fork PR #4](https://github.com/CyberoniOntoni/JellyBox/pull/4).

- Add `CollectionNavigation` to map `CollectionType` → `Library.Parameters`
- `NavigateToItem(Guid)` fetches item metadata and routes through the same logic as the DTO overload

## Merge order

1. #88 → #93 → #94
2. **This PR** — collection navigation
3. #98 — Xbox shell focus
4. #97 — Xbox packaging

## Test plan
- [x] Side menu and Home tiles open library views for Movies, TV Shows, Collections, Books