### PR TITLE
Add Xbox packaging profile and manifest targets

### DIFF
--- a/src/JellyBox/JellyBox.csproj
+++ b/src/JellyBox/JellyBox.csproj
@@ -9,7 +9,7 @@
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <DefaultLanguage>en-US</DefaultLanguage>
     <PublishAot>true</PublishAot>
-    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <PublishProfile Condition="'$(PublishProfile)' == '' and '$(Platform)' == 'x64'">win-x64.pubxml</PublishProfile>
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     <DisableEmbeddedXbf>true</DisableEmbeddedXbf>
     <EnableMsixTooling>true</EnableMsixTooling>

--- a/src/JellyBox/Package.appxmanifest
+++ b/src/JellyBox/Package.appxmanifest
@@ -21,7 +21,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.22000.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>
@@ -30,7 +30,7 @@
 
   <Applications>
     <Application Id="App"
-      Executable="$targetnametoken$.exe"
+      Executable="JellyBox.exe"
       EntryPoint="JellyBox.App">
       <uap:VisualElements
         DisplayName="JellyBox"

--- a/src/JellyBox/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/JellyBox/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Sideload-only publish profile for Xbox Release packages.
+  Produces a self-contained Native AOT build for win-x64 sideloading (not Store upload).
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <UapAppxPackageBuildMode>SideloadOnly</UapAppxPackageBuildMode>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

Xbox Series X/S packaging and publish profile tweaks.

> **Review tip:** For the ~20-line incremental diff, use the [fork compare view](https://github.com/CyberoniOntoni/JellyBox/compare/feature/xbox-shell-focus...feature/xbox-packaging) or [fork PR #5](https://github.com/CyberoniOntoni/JellyBox/pull/5).

- Target Xbox OS 22000+ in manifest; `JellyBox.exe` entry point for Native AOT
- Add `win-x64.pubxml` publish profile

## Merge order

Merge after #98 (shell focus).

## Test plan
- [x] Release | x64 publish and Xbox Series X deploy