### PR TITLE
Cancel superseded async page loads to fix stale-load race

### DIFF
--- a/src/JellyBox/CancellableLoad.cs
+++ b/src/JellyBox/CancellableLoad.cs
@@ -1,0 +1,49 @@
+namespace JellyBox;
+
+/// <summary>
+/// Coordinates a single in-flight asynchronous load so that starting a new load cancels any
+/// prior one. This prevents a superseded load's post-await continuation from overwriting
+/// view-model state after a newer load has begun (the stale-load race during rapid navigation
+/// or refresh).
+/// </summary>
+// CA1001: The CancellationTokenSource assigned to _cts is owned and disposed by the RunAsync
+// call that created it (via the local 'using'); this field only retains a transient reference so
+// a superseded load can be cancelled, so this type itself does not need to be IDisposable.
+#pragma warning disable CA1001
+internal sealed class CancellableLoad
+#pragma warning restore CA1001
+{
+    private CancellationTokenSource? _cts;
+
+    /// <summary>
+    /// Cancels any prior in-flight load, then runs <paramref name="operation"/> with a fresh
+    /// cancellation token. If this load is itself superseded by a later call, the resulting
+    /// cancellation is swallowed.
+    /// </summary>
+    /// <param name="operation">The load to run, observing the supplied cancellation token.</param>
+    public async Task RunAsync(Func<CancellationToken, Task> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        using CancellationTokenSource cts = new();
+        CancellationTokenSource? previous = Interlocked.Exchange(ref _cts, cts);
+        if (previous is not null)
+        {
+            await previous.CancelAsync();
+        }
+
+        CancellationToken token = cts.Token;
+        try
+        {
+            await operation(token);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            // Superseded by a newer load; discard this result.
+        }
+        finally
+        {
+            Interlocked.CompareExchange(ref _cts, null, cts);
+        }
+    }
+}

--- a/src/JellyBox/ViewModels/HomeViewModel.cs
+++ b/src/JellyBox/ViewModels/HomeViewModel.cs
@@ -11,6 +11,7 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
 {
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly CardFactory _cardFactory;
+    private readonly CancellableLoad _load = new();
 
     [ObservableProperty]
     public partial bool IsLoading { get; set; }
@@ -26,19 +27,21 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
         _cardFactory = cardFactory;
     }
 
-    public async void Initialize()
+    public void Initialize() => _ = _load.RunAsync(LoadAsync);
+
+    private async Task LoadAsync(CancellationToken cancellationToken)
     {
         IsLoading = true;
         try
         {
             Task<Section?>[] sectionTasks =
             [
-                GetUserViewsSectionAsync(),
-                GetResumeSectionAsync("Continue Watching", MediaType.Video),
-                GetResumeSectionAsync("Continue Listening", MediaType.Audio),
-                GetResumeSectionAsync("Continue Reading", MediaType.Book),
+                GetUserViewsSectionAsync(cancellationToken),
+                GetResumeSectionAsync("Continue Watching", MediaType.Video, cancellationToken),
+                GetResumeSectionAsync("Continue Listening", MediaType.Audio, cancellationToken),
+                GetResumeSectionAsync("Continue Reading", MediaType.Book, cancellationToken),
                 // TODO: LiveTV Section,
-                GetNextUpSectionAsync(),
+                GetNextUpSectionAsync(cancellationToken),
                 // TODO: LatestMedia Sections
             ];
 
@@ -53,7 +56,12 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
                 }
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             Sections = sections;
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load; leave state for the newer load to populate.
         }
         catch (Exception ex)
         {
@@ -61,17 +69,20 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
         }
         finally
         {
-            IsLoading = false;
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                IsLoading = false;
+            }
         }
     }
 
-    private async Task<Section?> GetUserViewsSectionAsync()
+    private async Task<Section?> GetUserViewsSectionAsync(CancellationToken cancellationToken)
     {
-        BaseItemDtoQueryResult? result = await _jellyfinApiClient.UserViews.GetAsync();
+        BaseItemDtoQueryResult? result = await _jellyfinApiClient.UserViews.GetAsync(cancellationToken: cancellationToken);
         return CreateSection("My Media", result, CardShape.Backdrop, preferredImageType: null);
     }
 
-    private async Task<Section?> GetResumeSectionAsync(string name, MediaType mediaType)
+    private async Task<Section?> GetResumeSectionAsync(string name, MediaType mediaType, CancellationToken cancellationToken)
     {
         BaseItemDtoQueryResult? result = await _jellyfinApiClient.UserItems.Resume.GetAsync(requestConfig =>
         {
@@ -81,14 +92,14 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
             requestConfig.QueryParameters.EnableImageTypes = [ImageType.Primary, ImageType.Backdrop, ImageType.Thumb];
             requestConfig.QueryParameters.EnableTotalRecordCount = false;
             requestConfig.QueryParameters.MediaTypes = [mediaType];
-        });
+        }, cancellationToken);
 
         return CreateSection(name, result, CardShape.Backdrop, ImageType.Thumb);
     }
 
-    private async Task<Section?> GetNextUpSectionAsync()
+    private async Task<Section?> GetNextUpSectionAsync(CancellationToken cancellationToken)
     {
-        BaseItemDtoQueryResult? result = await _jellyfinApiClient.Shows.NextUp.GetAsync();
+        BaseItemDtoQueryResult? result = await _jellyfinApiClient.Shows.NextUp.GetAsync(cancellationToken: cancellationToken);
         return CreateSection("Next Up", result, CardShape.Backdrop, ImageType.Thumb);
     }
 

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -28,6 +28,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
     private readonly JellyfinImageResolver _imageResolver;
     private readonly NavigationManager _navigationManager;
     private readonly CardFactory _cardFactory;
+    private readonly CancellableLoad _load = new();
 
     [ObservableProperty]
     public partial BaseItemDto? Item { get; set; }
@@ -143,11 +144,17 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         _cardFactory = cardFactory;
     }
 
-    internal async void HandleParameters(ItemDetails.Parameters parameters)
+    internal void HandleParameters(ItemDetails.Parameters parameters)
+        => _ = _load.RunAsync(cancellationToken => LoadAsync(parameters.ItemId, cancellationToken));
+
+    private async Task LoadAsync(Guid itemId, CancellationToken cancellationToken)
     {
         try
         {
-            Item = await _jellyfinApiClient.Items[parameters.ItemId].GetAsync();
+            BaseItemDto? item = await _jellyfinApiClient.Items[itemId].GetAsync(cancellationToken: cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Item = item;
 
             Name = Item!.Name;
 
@@ -220,8 +227,8 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
             Task<Section?>[] sectionTasks =
             [
-                GetNextUpSectionAsync(),
-                GetChildrenSectionAsync(),
+                GetNextUpSectionAsync(cancellationToken),
+                GetChildrenSectionAsync(cancellationToken),
                 GetCastSectionAsync("Cast & Crew", getGuestStars: false),
                 GetCastSectionAsync("Guest Stars", getGuestStars: true),
                 // TODO: Special Features
@@ -238,7 +245,12 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
                 }
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             Sections = sections;
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load; leave state for the newer load to populate.
         }
         catch (Exception ex)
         {
@@ -521,7 +533,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         ResumePositionText = CanResume ? FormatResumePosition(positionTicks) : null;
     }
 
-    private async Task<Section?> GetNextUpSectionAsync()
+    private async Task<Section?> GetNextUpSectionAsync(CancellationToken cancellationToken)
     {
         if (Item is null)
         {
@@ -536,7 +548,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         BaseItemDtoQueryResult? result = await _jellyfinApiClient.Shows.NextUp.GetAsync(request =>
         {
             request.QueryParameters.SeriesId = Item.Id;
-        });
+        }, cancellationToken);
         if (result?.Items is null || result.Items.Count == 0)
         {
             return null;
@@ -560,7 +572,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         };
     }
 
-    private async Task<Section?> GetChildrenSectionAsync()
+    private async Task<Section?> GetChildrenSectionAsync(CancellationToken cancellationToken)
     {
         if (Item is null)
         {
@@ -578,7 +590,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             result = await _jellyfinApiClient.Shows[Item.Id!.Value].Seasons.GetAsync(request =>
             {
                 request.QueryParameters.Fields = [ItemFields.ItemCounts, ItemFields.PrimaryImageAspectRatio, ItemFields.CanDelete, ItemFields.MediaSourceCount];
-            });
+            }, cancellationToken);
         }
         else if (Item.Type == BaseItemDto_Type.Season)
         {
@@ -586,7 +598,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             {
                 request.QueryParameters.SeasonId = Item.Id;
                 request.QueryParameters.Fields = [ItemFields.ItemCounts, ItemFields.PrimaryImageAspectRatio, ItemFields.CanDelete, ItemFields.MediaSourceCount, ItemFields.Overview];
-            });
+            }, cancellationToken);
         }
         else
         {
@@ -607,7 +619,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
                 {
                     request.QueryParameters.SortBy = [ItemSortBy.PremiereDate, ItemSortBy.ProductionYear, ItemSortBy.SortName];
                 }
-            });
+            }, cancellationToken);
         }
 
         if (result?.Items is null)

--- a/src/JellyBox/ViewModels/LibraryViewModel.Filtering.cs
+++ b/src/JellyBox/ViewModels/LibraryViewModel.Filtering.cs
@@ -39,7 +39,7 @@ internal sealed partial class LibraryViewModel
     partial void OnIsSortDescendingChanged(bool value)
     {
         SaveViewSettings();
-        _ = RefreshItemsAsync();
+        _ = _load.RunAsync(RefreshAsync);
     }
 
     [RelayCommand]
@@ -47,7 +47,7 @@ internal sealed partial class LibraryViewModel
     {
         SelectedSortOption = option;
         SaveViewSettings();
-        _ = RefreshItemsAsync();
+        _ = _load.RunAsync(RefreshAsync);
     }
 
     [RelayCommand]
@@ -71,7 +71,7 @@ internal sealed partial class LibraryViewModel
 
         UpdateHasActiveFilters();
         SaveViewSettings();
-        _ = RefreshItemsAsync();
+        _ = _load.RunAsync(RefreshAsync);
 
         static void UnselectAll(List<FilterItem> filters)
         {
@@ -91,7 +91,7 @@ internal sealed partial class LibraryViewModel
 
         UpdateHasActiveFilters();
         SaveViewSettings();
-        _ = RefreshItemsAsync();
+        _ = _load.RunAsync(RefreshAsync);
     }
 
     private void UpdateHasActiveFilters()
@@ -113,7 +113,7 @@ internal sealed partial class LibraryViewModel
         ];
     }
 
-    private async Task LoadFilterValuesAsync()
+    private async Task LoadFilterValuesAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -121,7 +121,7 @@ internal sealed partial class LibraryViewModel
             {
                 parameters.QueryParameters.ParentId = _collectionItemId;
                 parameters.QueryParameters.IncludeItemTypes = [_itemKind];
-            });
+            }, cancellationToken);
 
             if (filters is not null)
             {
@@ -160,6 +160,11 @@ internal sealed partial class LibraryViewModel
 
                 UpdateHasActiveFilters();
             }
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load; let the caller unwind without logging.
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/JellyBox/ViewModels/LibraryViewModel.cs
+++ b/src/JellyBox/ViewModels/LibraryViewModel.cs
@@ -14,6 +14,7 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
     private readonly AppSettings _appSettings;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly CardFactory _cardFactory;
+    private readonly CancellableLoad _load = new();
 
     private Guid _collectionItemId;
     private BaseItemKind _itemKind;
@@ -62,18 +63,22 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
         RestoreFilterSelections(StatusFilters, _savedViewSettings.StatusFilters);
 
         _suppressRefresh = false;
-        _ = InitializeAsync();
+        _ = _load.RunAsync(InitializeAsync);
     }
 
-    private async Task InitializeAsync()
+    private async Task InitializeAsync(CancellationToken cancellationToken)
     {
         IsLoading = true;
 
         try
         {
             // Load filter values first so saved selections are restored before querying items
-            await LoadFilterValuesAsync();
-            await LoadItemsAsync();
+            await LoadFilterValuesAsync(cancellationToken);
+            await LoadItemsAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load; leave state for the newer load to populate.
         }
         catch (Exception ex)
         {
@@ -81,11 +86,14 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
         }
         finally
         {
-            IsLoading = false;
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                IsLoading = false;
+            }
         }
     }
 
-    private async Task RefreshItemsAsync()
+    private async Task RefreshAsync(CancellationToken cancellationToken)
     {
         // Don't refresh if we haven't initialized yet
         if (SelectedSortOption is null)
@@ -97,19 +105,26 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
 
         try
         {
-            await LoadItemsAsync();
+            await LoadItemsAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer load; leave state for the newer load to populate.
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in LibraryViewModel.RefreshItemsAsync: {ex}");
+            Debug.WriteLine($"Error in LibraryViewModel.RefreshAsync: {ex}");
         }
         finally
         {
-            IsLoading = false;
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                IsLoading = false;
+            }
         }
     }
 
-    private async Task LoadItemsAsync()
+    private async Task LoadItemsAsync(CancellationToken cancellationToken)
     {
         string[] selectedGenres = [.. GenreFilters.Where(f => f.IsSelected).Select(f => f.Label)];
         int?[] selectedYears = [.. YearFilters.Where(f => f.IsSelected).Select(f => (int?)int.Parse(f.Label))];
@@ -150,7 +165,9 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
             {
                 parameters.QueryParameters.Filters = selectedStatusFilters;
             }
-        });
+        }, cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (result?.Items is not null)
         {


### PR DESCRIPTION
## What & why

Page ViewModels started their data loads as fire-and-forget async work with no
cancellation, so a superseded load's post-await continuation could overwrite newer
view-model state. The most reproducible case: rapidly changing a library's sort or
filters could leave the grid showing the results of an earlier selection.

This introduces a small shared `CancellableLoad` helper that owns a
`CancellationTokenSource`, cancels any prior in-flight load when a new one starts, and
swallows the superseded `OperationCanceledException`. `HomeViewModel`, `LibraryViewModel`
(including every sort/filter refresh path), and `ItemDetailsViewModel` route their load
entry points through it and thread the cancellation token into each Kiota `GetAsync` call,
so a superseded request is cancelled at the HTTP layer. Terminal state commits are guarded
with `ThrowIfCancellationRequested` so an already-completed request can't write stale state,
and `IsLoading` is only cleared by the surviving load.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Build / tooling
- [ ] Docs

## Checklist

- [x] **Single-purpose:** this PR makes one logical change and does not club
      together unrelated changes.
- [x] **Builds clean:** `msbuild JellyBox.sln -t:Build -p:Configuration=Debug -p:Platform=x64`
      succeeds with **0 warnings and 0 errors**.
- [ ] **UI/UX changes include screenshots or a short screen recording** — N/A; this is a
      data-loading correctness fix with no visual or layout change.
- [x] **Manual testing** is described below.
- [ ] Linked the related issue above (if one exists) — no tracking issue.

## Manual test notes

Windows desktop — rapidly toggled a library's sort direction, sort option, and filters in
quick succession. The grid consistently settles on the final selection's results, and the
loading indicator clears correctly.

## Screenshots / recording

N/A — no visual or layout change; this is a data-loading correctness fix.

## Out of scope / follow-ups

None.
