### PR TITLE
Fix shell search suggestion pick after dismissing OSK with B

### DIFF
--- a/src/JellyBox/App.xaml.cs
+++ b/src/JellyBox/App.xaml.cs
@@ -40,9 +40,20 @@ sealed partial class App : Application
 
         InitializeComponent();
 
+        UnhandledException += OnUnhandledException;
+
         Current.RequiresPointerMode = ApplicationRequiresPointerMode.WhenRequested;
 
         Suspending += OnSuspending;
+    }
+
+    private void OnUnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
+    {
+        System.Diagnostics.Debug.WriteLine($"Unhandled UI exception: {e.Exception}");
+        if (e.Exception.InnerException is not null)
+        {
+            System.Diagnostics.Debug.WriteLine($"Inner exception: {e.Exception.InnerException}");
+        }
     }
 
     /// <inheritdoc/>

--- a/src/JellyBox/AppServices.cs
+++ b/src/JellyBox/AppServices.cs
@@ -71,6 +71,8 @@ internal sealed class AppServices
         serviceCollection.AddTransient<LibraryViewModel>();
         serviceCollection.AddTransient<LoginViewModel>();
         serviceCollection.AddTransient<MainPageViewModel>();
+        serviceCollection.AddTransient<SearchViewModel>();
+        serviceCollection.AddTransient<ShellSearchViewModel>();
         serviceCollection.AddTransient<ServerSelectionViewModel>();
         serviceCollection.AddTransient<VideoViewModel>();
         serviceCollection.AddTransient<WebVideoViewModel>();

--- a/src/JellyBox/Behaviors/FocusFirstItemBehavior.cs
+++ b/src/JellyBox/Behaviors/FocusFirstItemBehavior.cs
@@ -8,7 +8,9 @@ namespace JellyBox.Behaviors;
 /// <summary>
 /// Automatically focuses the first item in a list once items are loaded and containers are realized.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class FocusFirstItemBehavior : Behavior<ListViewBase>
+#pragma warning restore CA1812
 {
     private bool _hasFocused;
 

--- a/src/JellyBox/Behaviors/FocusOnLoadBehavior.cs
+++ b/src/JellyBox/Behaviors/FocusOnLoadBehavior.cs
@@ -4,7 +4,9 @@ using Windows.UI.Xaml.Controls;
 
 namespace JellyBox.Behaviors;
 
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class FocusOnLoadBehavior : Behavior<Control>
+#pragma warning restore CA1812
 {
     protected override void OnAttached()
     {

--- a/src/JellyBox/Behaviors/ListViewBaseCommandBehavior.cs
+++ b/src/JellyBox/Behaviors/ListViewBaseCommandBehavior.cs
@@ -7,7 +7,9 @@ namespace JellyBox.Behaviors;
 /// <summary>
 /// Invokes the NavigateCommand on INavigable items when they are clicked in a ListViewBase control.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class ListViewBaseCommandBehavior : Behavior<ListViewBase>
+#pragma warning restore CA1812
 {
     protected override void OnAttached()
     {

--- a/src/JellyBox/Behaviors/ScrollOnFocusBehavior.cs
+++ b/src/JellyBox/Behaviors/ScrollOnFocusBehavior.cs
@@ -11,7 +11,9 @@ namespace JellyBox.Behaviors;
 /// Adjusts scroll position to keep focused items within the TV-safe zone.
 /// Supports both horizontal carousels and full grid layouts.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class ScrollOnFocusBehavior : Behavior<ListViewBase>
+#pragma warning restore CA1812
 {
     private ScrollViewer? _scrollViewer;
 

--- a/src/JellyBox/Behaviors/SectionNavigationBehavior.cs
+++ b/src/JellyBox/Behaviors/SectionNavigationBehavior.cs
@@ -1,3 +1,4 @@
+using JellyBox;
 using Microsoft.Xaml.Interactivity;
 using Windows.Foundation;
 using Windows.UI.Core;
@@ -11,9 +12,12 @@ namespace JellyBox.Behaviors;
 /// Handles vertical navigation between horizontal list rows within a sections container.
 /// Maintains horizontal position when moving between rows and handles edge trapping.
 /// </summary>
+#pragma warning disable CA1812 // Instantiated via XAML Interaction.Behaviors.
 internal sealed class SectionNavigationBehavior : Behavior<ItemsControl>
+#pragma warning restore CA1812
 {
     private ScrollViewer? _scrollViewer;
+    private MainPage? _mainPage;
 
     /// <summary>
     /// The ScrollViewer to use for bringing items into view.
@@ -55,6 +59,7 @@ internal sealed class SectionNavigationBehavior : Behavior<ItemsControl>
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         _scrollViewer = ScrollViewer ?? AssociatedObject.FindAncestor<ScrollViewer>();
+        _mainPage ??= AssociatedObject.FindAncestor<MainPage>();
     }
 
     private void OnGotFocus(object sender, RoutedEventArgs e)
@@ -100,7 +105,7 @@ internal sealed class SectionNavigationBehavior : Behavior<ItemsControl>
 
         if (targetIndex < 0)
         {
-            if (TrapAtTop)
+            if (TrapAtTop && _mainPage?.TryRedirectFocusToSearch(e) != true)
             {
                 e.TryCancel();
             }

--- a/src/JellyBox/CancellableLoad.cs
+++ b/src/JellyBox/CancellableLoad.cs
@@ -16,6 +16,18 @@ internal sealed class CancellableLoad
     private CancellationTokenSource? _cts;
 
     /// <summary>
+    /// Cancels any in-flight load without starting a new one.
+    /// </summary>
+    public async Task CancelAsync()
+    {
+        CancellationTokenSource? previous = Interlocked.Exchange(ref _cts, null);
+        if (previous is not null)
+        {
+            await previous.CancelAsync();
+        }
+    }
+
+    /// <summary>
     /// Cancels any prior in-flight load, then runs <paramref name="operation"/> with a fresh
     /// cancellation token. If this load is itself superseded by a later call, the resulting
     /// cancellation is swallowed.

--- a/src/JellyBox/Glyphs.cs
+++ b/src/JellyBox/Glyphs.cs
@@ -7,6 +7,7 @@ internal static class Glyphs
 {
     // Navigation
     public const string Home = "\uE80F";
+    public const string Search = "\uE721";
     public const string Library = "\uE8F1";
     public const string Switch = "\uE895";
     public const string SignOut = "\uE8BB";

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -2,16 +2,71 @@
     x:Class="JellyBox.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:models="using:JellyBox.Models"
+    xmlns:g="using:JellyBox"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{StaticResource BackgroundBase}">
 
     <Grid XYFocusKeyboardNavigation="Enabled">
-        <Frame x:Name="ContentFrame" />
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid
+            Grid.Row="0"
+            Padding="48,20,48,12"
+            Background="{StaticResource BackgroundBase}"
+            XYFocusKeyboardNavigation="Enabled">
+            <AutoSuggestBox
+                x:Name="SearchBox"
+                MaxWidth="720"
+                HorizontalAlignment="Stretch"
+                IsTabStop="False"
+                PlaceholderText="Search movies and TV shows"
+                Style="{StaticResource SearchAutoSuggestBox}"
+                ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
+                TextChanged="SearchBox_TextChanged"
+                QuerySubmitted="SearchBox_QuerySubmitted"
+                SuggestionChosen="SearchBox_SuggestionChosen"
+                LostFocus="SearchBox_LostFocus"
+                XYFocusKeyboardNavigation="Enabled">
+                <AutoSuggestBox.QueryIcon>
+                    <SymbolIcon Symbol="Find" />
+                </AutoSuggestBox.QueryIcon>
+                <AutoSuggestBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:SearchSuggestion">
+                        <StackPanel Orientation="Horizontal" Spacing="12" Padding="4,10">
+                            <FontIcon
+                                FontFamily="{StaticResource SegoeIcons}"
+                                Glyph="{x:Bind g:Glyphs.Search}"
+                                FontSize="16"
+                                Foreground="{StaticResource TextMuted}"
+                                VerticalAlignment="Center" />
+                            <StackPanel Spacing="2" VerticalAlignment="Center">
+                                <TextBlock
+                                    Text="{x:Bind DisplayText}"
+                                    FontSize="{StaticResource FontS}"
+                                    Foreground="{StaticResource TextPrimary}" />
+                                <TextBlock
+                                    Text="{x:Bind SecondaryText}"
+                                    FontSize="{StaticResource FontXS}"
+                                    Foreground="{StaticResource TextMuted}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </AutoSuggestBox.ItemTemplate>
+            </AutoSuggestBox>
+        </Grid>
+
+        <Frame x:Name="ContentFrame" Grid.Row="1" />
 
         <Grid
             x:Name="NavigationOverlay"
+            Grid.Row="0"
+            Grid.RowSpan="2"
             Visibility="Collapsed"
             XYFocusKeyboardNavigation="Enabled">
 

--- a/src/JellyBox/MainPage.xaml
+++ b/src/JellyBox/MainPage.xaml
@@ -27,10 +27,10 @@
                 IsTabStop="False"
                 PlaceholderText="Search movies and TV shows"
                 Style="{StaticResource SearchAutoSuggestBox}"
+                UpdateTextOnSelect="False"
                 ItemsSource="{x:Bind ViewModel.Search.Suggestions, Mode=OneWay}"
                 TextChanged="SearchBox_TextChanged"
                 QuerySubmitted="SearchBox_QuerySubmitted"
-                SuggestionChosen="SearchBox_SuggestionChosen"
                 LostFocus="SearchBox_LostFocus"
                 XYFocusKeyboardNavigation="Enabled">
                 <AutoSuggestBox.QueryIcon>
@@ -38,7 +38,11 @@
                 </AutoSuggestBox.QueryIcon>
                 <AutoSuggestBox.ItemTemplate>
                     <DataTemplate x:DataType="models:SearchSuggestion">
-                        <StackPanel Orientation="Horizontal" Spacing="12" Padding="4,10">
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="12"
+                            Padding="4,10"
+                            Tapped="SearchSuggestionItem_Tapped">
                             <FontIcon
                                 FontFamily="{StaticResource SegoeIcons}"
                                 Glyph="{x:Bind g:Glyphs.Search}"

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,4 +1,6 @@
+using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using JellyBox.Models;
 using JellyBox.Services;
 using JellyBox.ViewModels;
@@ -8,14 +10,18 @@ using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
 namespace JellyBox;
 
 internal sealed partial class MainPage : Page
 {
+    private static readonly TimeSpan OskDismissQuerySubmitSuppressWindow = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan SuggestionPickQuerySubmitSuppressWindow = TimeSpan.FromMilliseconds(300);
+
     private FrameworkElement? _lastFocusedElement;
-    private bool _ignoreNextQuerySubmitted;
+    private DateTimeOffset _suppressQuerySubmittedUntil;
     private bool _suppressSearchTextSync;
 
     public MainPage()
@@ -25,6 +31,7 @@ internal sealed partial class MainPage : Page
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<MainPageViewModel>();
         ViewModel.IsMenuOpenChanged += OnIsMenuOpenChanged;
         ViewModel.Search.PropertyChanged += OnSearchPropertyChanged;
+        PreviewKeyDown += MainPage_PreviewKeyDown;
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
@@ -41,6 +48,7 @@ internal sealed partial class MainPage : Page
         {
             ContentFrame.Navigated -= ContentFrameNavigated;
             ViewModel.Search.PropertyChanged -= OnSearchPropertyChanged;
+            PreviewKeyDown -= MainPage_PreviewKeyDown;
         };
     }
 
@@ -135,7 +143,46 @@ internal sealed partial class MainPage : Page
 
     private void SearchBox_LostFocus(object sender, RoutedEventArgs e)
     {
+        // Keep the search box in the focus order while suggestions are open so the user
+        // can dismiss the OSK with B and navigate the list with the d-pad.
+        if (ViewModel.Search.Suggestions.Count > 0)
+        {
+            return;
+        }
+
         SearchBox.IsTabStop = false;
+    }
+
+    private void MainPage_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (!IsSearchSuggestionsActive())
+        {
+            return;
+        }
+
+        if (GamepadInput.IsBackKey(e.Key))
+        {
+            // On Xbox, dismissing the OSK with B fires QuerySubmitted for the first suggestion.
+            SuppressQuerySubmitted(OskDismissQuerySubmitSuppressWindow);
+            return;
+        }
+
+        if (GamepadInput.IsAcceptKey(e.Key) && TryGetFocusedSuggestion(out SearchSuggestion? suggestion))
+        {
+            // Handle gamepad selection here instead of SuggestionChosen, which throws
+            // InvalidCastException for custom suggestion items inside AutoSuggestBox on Xbox.
+            e.Handled = true;
+            OpenSearchSuggestion(suggestion);
+        }
+    }
+
+    private void SearchSuggestionItem_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        if (sender is FrameworkElement element && element.DataContext is SearchSuggestion suggestion)
+        {
+            e.Handled = true;
+            OpenSearchSuggestion(suggestion);
+        }
     }
 
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
@@ -159,15 +206,15 @@ internal sealed partial class MainPage : Page
     {
         if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
         {
+            ClearQuerySubmittedSuppression();
             ViewModel.Search.Query = sender.Text ?? string.Empty;
         }
     }
 
     private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
     {
-        if (_ignoreNextQuerySubmitted)
+        if (IsQuerySubmittedSuppressed())
         {
-            _ignoreNextQuerySubmitted = false;
             return;
         }
 
@@ -180,29 +227,26 @@ internal sealed partial class MainPage : Page
         ViewModel.Search.SubmitQuery(args.QueryText);
     }
 
-    private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
-    {
-        if (args.SelectedItem is SearchSuggestion suggestion)
-        {
-            OpenSearchSuggestion(suggestion);
-        }
-    }
-
     private void OpenSearchSuggestion(SearchSuggestion suggestion)
     {
-        _ignoreNextQuerySubmitted = true;
+        SuppressQuerySubmitted(SuggestionPickQuerySubmitSuppressWindow);
+        ViewModel.Search.SelectSuggestion(suggestion);
+    }
 
-        _suppressSearchTextSync = true;
-        try
+    private bool IsQuerySubmittedSuppressed()
+        => DateTimeOffset.UtcNow < _suppressQuerySubmittedUntil;
+
+    private void SuppressQuerySubmitted(TimeSpan window)
+    {
+        DateTimeOffset until = DateTimeOffset.UtcNow + window;
+        if (until > _suppressQuerySubmittedUntil)
         {
-            SearchBox.Text = string.Empty;
-            ViewModel.Search.SelectSuggestion(suggestion);
-        }
-        finally
-        {
-            _suppressSearchTextSync = false;
+            _suppressQuerySubmittedUntil = until;
         }
     }
+
+    private void ClearQuerySubmittedSuppression()
+        => _suppressQuerySubmittedUntil = DateTimeOffset.MinValue;
 
     private void ClearSearchField()
     {
@@ -221,6 +265,51 @@ internal sealed partial class MainPage : Page
         {
             _suppressSearchTextSync = false;
         }
+    }
+
+    private bool IsSearchSuggestionsActive()
+    {
+        if (ViewModel.Search.Suggestions.Count == 0)
+        {
+            return false;
+        }
+
+        return IsSearchBoxFocused() || TryGetFocusedSuggestion(out _);
+    }
+
+    private bool IsSearchBoxFocused()
+    {
+        for (DependencyObject? current = FocusManager.GetFocusedElement() as DependencyObject;
+             current is not null;
+             current = VisualTreeHelper.GetParent(current))
+        {
+            if (current == SearchBox)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetFocusedSuggestion([NotNullWhen(true)] out SearchSuggestion? suggestion)
+    {
+        suggestion = null;
+        if (FocusManager.GetFocusedElement() is not DependencyObject focused)
+        {
+            return false;
+        }
+
+        for (DependencyObject? current = focused; current is not null; current = VisualTreeHelper.GetParent(current))
+        {
+            if (current is FrameworkElement { DataContext: SearchSuggestion context })
+            {
+                suggestion = context;
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/MainPage.xaml.cs
+++ b/src/JellyBox/MainPage.xaml.cs
@@ -1,4 +1,8 @@
+using System.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Services;
 using JellyBox.ViewModels;
+using JellyBox.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -11,6 +15,8 @@ namespace JellyBox;
 internal sealed partial class MainPage : Page
 {
     private FrameworkElement? _lastFocusedElement;
+    private bool _ignoreNextQuerySubmitted;
+    private bool _suppressSearchTextSync;
 
     public MainPage()
     {
@@ -18,6 +24,7 @@ internal sealed partial class MainPage : Page
 
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<MainPageViewModel>();
         ViewModel.IsMenuOpenChanged += OnIsMenuOpenChanged;
+        ViewModel.Search.PropertyChanged += OnSearchPropertyChanged;
 
         // Cache the page state so the ContentFrame's BackStack can be preserved
         NavigationCacheMode = NavigationCacheMode.Required;
@@ -33,6 +40,7 @@ internal sealed partial class MainPage : Page
         Unloaded += (sender, e) =>
         {
             ContentFrame.Navigated -= ContentFrameNavigated;
+            ViewModel.Search.PropertyChanged -= OnSearchPropertyChanged;
         };
     }
 
@@ -43,6 +51,18 @@ internal sealed partial class MainPage : Page
         ViewModel.HandleParameters(e.Parameter as Parameters, ContentFrame);
 
         base.OnNavigatedTo(e);
+    }
+
+    internal void OnContentNavigated()
+    {
+        // FocusState.Unfocused is invalid for Control.Focus and throws on Xbox.
+        SearchBox.IsTabStop = false;
+    }
+
+    internal bool TryRedirectFocusToSearch(LosingFocusEventArgs e)
+    {
+        SearchBox.IsTabStop = true;
+        return e.TrySetNewFocusedElement(SearchBox);
     }
 
     private void OnIsMenuOpenChanged(bool isOpen)
@@ -101,14 +121,106 @@ internal sealed partial class MainPage : Page
             CoreDispatcherPriority.Normal,
             () =>
             {
+                OnContentNavigated();
+
+                if (e.SourcePageType != typeof(Search))
+                {
+                    ClearSearchField();
+                }
+
                 ViewModel.CloseNavigationCommand.Execute(null);
                 ViewModel.UpdateSelectedMenuItem();
             });
     }
 
+    private void SearchBox_LostFocus(object sender, RoutedEventArgs e)
+    {
+        SearchBox.IsTabStop = false;
+    }
+
     private void CloseNavigation(object sender, TappedRoutedEventArgs e)
     {
         ViewModel.CloseNavigationCommand.Execute(null);
+    }
+
+    private void OnSearchPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_suppressSearchTextSync
+            || e.PropertyName is not nameof(ShellSearchViewModel.Query)
+            || SearchBox.Text == ViewModel.Search.Query)
+        {
+            return;
+        }
+
+        SearchBox.Text = ViewModel.Search.Query;
+    }
+
+    private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+    {
+        if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+        {
+            ViewModel.Search.Query = sender.Text ?? string.Empty;
+        }
+    }
+
+    private void SearchBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+    {
+        if (_ignoreNextQuerySubmitted)
+        {
+            _ignoreNextQuerySubmitted = false;
+            return;
+        }
+
+        if (args.ChosenSuggestion is SearchSuggestion suggestion)
+        {
+            OpenSearchSuggestion(suggestion);
+            return;
+        }
+
+        ViewModel.Search.SubmitQuery(args.QueryText);
+    }
+
+    private void SearchBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+    {
+        if (args.SelectedItem is SearchSuggestion suggestion)
+        {
+            OpenSearchSuggestion(suggestion);
+        }
+    }
+
+    private void OpenSearchSuggestion(SearchSuggestion suggestion)
+    {
+        _ignoreNextQuerySubmitted = true;
+
+        _suppressSearchTextSync = true;
+        try
+        {
+            SearchBox.Text = string.Empty;
+            ViewModel.Search.SelectSuggestion(suggestion);
+        }
+        finally
+        {
+            _suppressSearchTextSync = false;
+        }
+    }
+
+    private void ClearSearchField()
+    {
+        if (string.IsNullOrEmpty(ViewModel.Search.Query) && string.IsNullOrEmpty(SearchBox.Text))
+        {
+            return;
+        }
+
+        _suppressSearchTextSync = true;
+        try
+        {
+            ViewModel.Search.ClearQuery();
+            SearchBox.Text = string.Empty;
+        }
+        finally
+        {
+            _suppressSearchTextSync = false;
+        }
     }
 
     internal sealed record Parameters(Action DeferredNavigationAction);

--- a/src/JellyBox/Models/SearchSuggestion.cs
+++ b/src/JellyBox/Models/SearchSuggestion.cs
@@ -1,0 +1,3 @@
+namespace JellyBox.Models;
+
+internal sealed record SearchSuggestion(string DisplayText, string? SecondaryText, Guid ItemId);

--- a/src/JellyBox/Resources/Styles.xaml
+++ b/src/JellyBox/Resources/Styles.xaml
@@ -1008,6 +1008,16 @@
         </Setter>
     </Style>
 
+    <Style x:Key="SearchAutoSuggestBox" TargetType="AutoSuggestBox">
+        <Setter Property="MinHeight" Value="48" />
+        <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
+        <Setter Property="FontSize" Value="{StaticResource FontM}" />
+        <Setter Property="UseSystemFocusVisuals" Value="True" />
+        <Setter Property="FocusVisualPrimaryBrush" Value="{StaticResource FocusBorder}" />
+        <Setter Property="FocusVisualSecondaryBrush" Value="Transparent" />
+        <Setter Property="FocusVisualPrimaryThickness" Value="3" />
+    </Style>
+
     <Style x:Key="PrimaryTextBox"  TargetType="TextBox">
         <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
         <Setter Property="MinHeight" Value="40" />

--- a/src/JellyBox/Services/CollectionNavigation.cs
+++ b/src/JellyBox/Services/CollectionNavigation.cs
@@ -1,0 +1,56 @@
+using JellyBox.Views;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.Services;
+
+internal static class CollectionNavigation
+{
+    internal static bool TryCreateLibraryParameters(BaseItemDto item, out Library.Parameters parameters)
+    {
+        parameters = default!;
+
+        if (item.Type is not BaseItemDto_Type.CollectionFolder
+            || !item.Id.HasValue
+            || !TryMapCollectionType(item.CollectionType, out BaseItemKind itemKind, out string defaultTitle))
+        {
+            return false;
+        }
+
+        parameters = new Library.Parameters(
+            item.Id.Value,
+            itemKind,
+            item.Name ?? defaultTitle);
+
+        return true;
+    }
+
+    private static bool TryMapCollectionType(
+        BaseItemDto_CollectionType? collectionType,
+        out BaseItemKind itemKind,
+        out string defaultTitle)
+    {
+        switch (collectionType)
+        {
+            case BaseItemDto_CollectionType.Movies:
+                itemKind = BaseItemKind.Movie;
+                defaultTitle = "Movies";
+                return true;
+            case BaseItemDto_CollectionType.Tvshows:
+                itemKind = BaseItemKind.Series;
+                defaultTitle = "TV Shows";
+                return true;
+            case BaseItemDto_CollectionType.Boxsets:
+                itemKind = BaseItemKind.BoxSet;
+                defaultTitle = "Collections";
+                return true;
+            case BaseItemDto_CollectionType.Books:
+                itemKind = BaseItemKind.Book;
+                defaultTitle = "Books";
+                return true;
+            default:
+                itemKind = default;
+                defaultTitle = "Library";
+                return false;
+        }
+    }
+}

--- a/src/JellyBox/Services/GamepadInput.cs
+++ b/src/JellyBox/Services/GamepadInput.cs
@@ -10,7 +10,7 @@ namespace JellyBox.Services;
 internal static class GamepadInput
 {
     public static bool IsTextInputFocused()
-        => FocusManager.GetFocusedElement() is TextBox or PasswordBox;
+        => FocusManager.GetFocusedElement() is TextBox or PasswordBox or AutoSuggestBox;
 
     public static bool IsAcceptKey(VirtualKey key)
         => key is VirtualKey.Enter or VirtualKey.GamepadA or VirtualKey.Space;

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics;
 using JellyBox.Views;
+using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.Core;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Input;
@@ -15,6 +19,9 @@ internal sealed class NavigationManager
 {
     // Fake item id used to identify the home page
     public static readonly Guid HomeId = new Guid("CDF95D47-90C2-4057-B12C-BA81C34F2CB9");
+
+    // Fake item id used to identify the search page
+    public static readonly Guid SearchId = new Guid("A4B8C2E1-6F3D-4A91-9B7E-2D5C8F1A3E64");
 
     /// <summary>
     /// Opens the shell navigation menu.
@@ -38,6 +45,13 @@ internal sealed class NavigationManager
     private object? _currentAppParameter;
 
     private object? _currentContentParameter;
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+
+    public NavigationManager(JellyfinApiClient jellyfinApiClient)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+    }
 
     /// <summary>
     /// Gets the item associated with the current page.
@@ -94,34 +108,63 @@ internal sealed class NavigationManager
         NavigateContentFrame<Home>();
     }
 
-    public void NavigateToItem(BaseItemDto item)
+    public void NavigateToSearch(string query)
     {
-        Guid itemId = item.Id!.Value;
-        if (item.Type == BaseItemDto_Type.CollectionFolder)
+        CurrentItem = SearchId;
+        Search.Parameters parameters = new(query);
+
+        if (_contentFrame is not null
+            && _contentFrame.CurrentSourcePageType == typeof(Search)
+            && Equals(_currentContentParameter, parameters))
         {
-            switch (item.CollectionType)
+            if (_contentFrame.Content is Search searchPage)
             {
-                case BaseItemDto_CollectionType.Movies:
-                {
-                    CurrentItem = itemId;
-                    NavigateContentFrame<Library>(new Library.Parameters(itemId, BaseItemKind.Movie, item.Name ?? "Movies"));
-                    return;
-                }
-                case BaseItemDto_CollectionType.Tvshows:
-                {
-                    CurrentItem = itemId;
-                    NavigateContentFrame<Library>(new Library.Parameters(itemId, BaseItemKind.Series, item.Name ?? "TV Shows"));
-                    return;
-                }
+                searchPage.ViewModel.HandleParameters(parameters);
             }
 
-            // TODO: Some kind of error message. Or genericize the collection view.
+            return;
         }
-        else
+
+        NavigateContentFrame<Search>(parameters);
+    }
+
+    public void NavigateToItem(Guid itemId) => _ = NavigateToItemAsync(itemId);
+
+    public void NavigateToItem(BaseItemDto item) => NavigateToResolvedItem(item);
+
+    private async Task NavigateToItemAsync(Guid itemId)
+    {
+        try
+        {
+            BaseItemDto? item = await _jellyfinApiClient.Items[itemId].GetAsync();
+            if (item is null)
+            {
+                return;
+            }
+
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
+                CoreDispatcherPriority.Normal,
+                () => NavigateToResolvedItem(item));
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in NavigationManager.NavigateToItemAsync: {ex}");
+        }
+    }
+
+    private void NavigateToResolvedItem(BaseItemDto item)
+    {
+        Guid itemId = item.Id!.Value;
+
+        if (CollectionNavigation.TryCreateLibraryParameters(item, out Library.Parameters libraryParameters))
         {
             CurrentItem = itemId;
-            NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
+            NavigateContentFrame<Library>(libraryParameters);
+            return;
         }
+
+        CurrentItem = itemId;
+        NavigateContentFrame<ItemDetails>(new ItemDetails.Parameters(itemId));
     }
 
     public void NavigateToPerson(BaseItemPerson person)

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -147,16 +147,25 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
     internal void HandleParameters(ItemDetails.Parameters parameters)
         => _ = _load.RunAsync(cancellationToken => LoadAsync(parameters.ItemId, cancellationToken));
 
+    public void CancelLoading() => _ = _load.CancelAsync();
+
     private async Task LoadAsync(Guid itemId, CancellationToken cancellationToken)
     {
+        ResetDisplayState();
+
         try
         {
             BaseItemDto? item = await _jellyfinApiClient.Items[itemId].GetAsync(cancellationToken: cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (item is null)
+            {
+                return;
+            }
+
             Item = item;
 
-            Name = Item!.Name;
+            Name = Item.Name;
 
             // Disable backdrop for Person and Book types because they only have primary images
             if (Item.Type is not BaseItemDto_Type.Person and not BaseItemDto_Type.Book)
@@ -206,12 +215,20 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
             if (Item.MediaSources is not null && Item.MediaSources.Count > 0)
             {
-                SourceContainers = new ObservableCollection<MediaSourceInfoWrapper>(Item.MediaSources.Select(s => new MediaSourceInfoWrapper(s.Name!, s)));
+                SourceContainers = new ObservableCollection<MediaSourceInfoWrapper>(
+                    Item.MediaSources.Select(s => new MediaSourceInfoWrapper(s.Name ?? "Unknown", s)));
                 HasMultipleSources = SourceContainers.Count > 1;
                 HasSingleSource = SourceContainers.Count == 1;
 
                 // This will trigger OnSelectedSourceContainerChanged, which populates the video, audio, and subtitle drop-downs.
                 SelectedSourceContainer = SourceContainers[0];
+            }
+            else
+            {
+                SourceContainers = null;
+                HasMultipleSources = false;
+                HasSingleSource = false;
+                SelectedSourceContainer = null;
             }
 
             TagLine = Item.Taglines is not null && Item.Taglines.Count > 0 ? Item.Taglines[0] : null;
@@ -239,6 +256,8 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             foreach (Task<Section?> sectionTask in sectionTasks)
             {
                 Section? section = await sectionTask;
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (section is not null)
                 {
                     sections.Add(section);
@@ -254,23 +273,58 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in HandleParameters: {ex}");
+            System.Diagnostics.Debug.WriteLine($"Error in ItemDetailsViewModel.LoadAsync: {ex}");
         }
     }
 
     partial void OnSelectedSourceContainerChanged(MediaSourceInfoWrapper? value)
     {
-        if (value is not null)
+        if (value is null)
+        {
+            return;
+        }
+
+        try
         {
             DetermineVideoOptions(value.Value);
             DetermineAudioOptions(value.Value);
             DetermineSubtitleOptions(value.Value);
         }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error in OnSelectedSourceContainerChanged: {ex}");
+        }
+    }
+
+    private void ResetDisplayState()
+    {
+        SourceContainers = null;
+        HasMultipleSources = false;
+        HasSingleSource = false;
+        SelectedSourceContainer = null;
+        VideoStreams = null;
+        SelectedVideoStream = null;
+        AudioStreams = null;
+        SelectedAudioStream = null;
+        HasMultipleAudioStreams = false;
+        HasSingleAudioStream = false;
+        SubtitleStreams = null;
+        SelectedSubtitleStream = null;
+        HasMultipleSubtitleStreams = false;
+        HasSingleSubtitleStream = false;
+        Sections = null;
     }
 
     private void DetermineVideoOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> videoStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            VideoStreams = [];
+            SelectedVideoStream = null;
+            return;
+        }
+
+        List<MediaStream> videoStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Video)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -302,7 +356,16 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     private void DetermineAudioOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> audioStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            AudioStreams = [];
+            HasMultipleAudioStreams = false;
+            HasSingleAudioStream = false;
+            SelectedAudioStream = null;
+            return;
+        }
+
+        List<MediaStream> audioStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Audio)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -330,7 +393,16 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
 
     private void DetermineSubtitleOptions(MediaSourceInfo mediaSourceInfo)
     {
-        List<MediaStream> subtitleStreams = mediaSourceInfo.MediaStreams!
+        if (mediaSourceInfo.MediaStreams is null)
+        {
+            SubtitleStreams = [MediaStreamOption.SubtitlesOff];
+            HasMultipleSubtitleStreams = false;
+            HasSingleSubtitleStream = true;
+            SelectedSubtitleStream = MediaStreamOption.SubtitlesOff;
+            return;
+        }
+
+        List<MediaStream> subtitleStreams = mediaSourceInfo.MediaStreams
             .Where(s => s.Type == MediaStream_Type.Subtitle)
             .OrderBy(s => s, MediaStreamComparer.Instance)
             .ToList();
@@ -523,7 +595,18 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             return;
         }
 
-        IsPlayed = Item.UserData!.Played.GetValueOrDefault();
+        if (Item.UserData is null)
+        {
+            IsPlayed = false;
+            IsFavorite = false;
+            CanResume = false;
+            PlayButtonText = "Play";
+            PlayButtonGlyph = Glyphs.Play;
+            ResumePositionText = null;
+            return;
+        }
+
+        IsPlayed = Item.UserData.Played.GetValueOrDefault();
         IsFavorite = Item.UserData.IsFavorite.GetValueOrDefault();
 
         long positionTicks = Item.UserData.PlaybackPositionTicks.GetValueOrDefault();

--- a/src/JellyBox/ViewModels/MainPageViewModel.cs
+++ b/src/JellyBox/ViewModels/MainPageViewModel.cs
@@ -26,14 +26,18 @@ internal sealed partial class MainPageViewModel : ObservableObject
     [ObservableProperty]
     public partial ObservableCollection<NavigationViewItemBase>? NavigationItems { get; set; }
 
+    public ShellSearchViewModel Search { get; }
+
     public MainPageViewModel(
         AppSettings appSettings,
         JellyfinApiClient jellyfinApiClient,
-        NavigationManager navigationManager)
+        NavigationManager navigationManager,
+        ShellSearchViewModel shellSearchViewModel)
     {
         _appSettings = appSettings;
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
+        Search = shellSearchViewModel;
         _navigationManager.OpenNavigationMenu = () => OpenNavigationCommand.Execute(null);
         _navigationManager.ToggleNavigationMenu = () => ToggleNavigationCommand.Execute(null);
         _navigationManager.TryCloseNavigationMenu = () =>
@@ -91,33 +95,42 @@ internal sealed partial class MainPageViewModel : ObservableObject
 
     public void UpdateSelectedMenuItem()
     {
-        Guid? currentItem = _navigationManager.CurrentItem;
-        if (!currentItem.HasValue)
+        if (NavigationItems is null)
         {
             return;
         }
 
-        if (NavigationItems is not null)
+        Guid? currentItem = _navigationManager.CurrentItem;
+        NavigationViewItem? selectedItem = null;
+
+        if (currentItem.HasValue && currentItem.Value != NavigationManager.SearchId)
         {
-            _isUpdatingSelection = true;
-            try
+            foreach (NavigationViewItemBase item in NavigationItems)
             {
-                foreach (NavigationViewItemBase item in NavigationItems)
+                if (item is NavigationViewItem navItem
+                    && item.Tag is NavigationViewItemContext context
+                    && context.ItemId == currentItem)
                 {
-                    if (item.Tag is NavigationViewItemContext context)
-                    {
-                        if (context.ItemId == currentItem)
-                        {
-                            item.IsSelected = true;
-                            break;
-                        }
-                    }
+                    selectedItem = navItem;
+                    break;
                 }
             }
-            finally
+        }
+
+        _isUpdatingSelection = true;
+        try
+        {
+            foreach (NavigationViewItemBase item in NavigationItems)
             {
-                _isUpdatingSelection = false;
+                if (item is NavigationViewItem navItem)
+                {
+                    navItem.IsSelected = ReferenceEquals(navItem, selectedItem);
+                }
             }
+        }
+        finally
+        {
+            _isUpdatingSelection = false;
         }
     }
 

--- a/src/JellyBox/ViewModels/SearchViewModel.cs
+++ b/src/JellyBox/ViewModels/SearchViewModel.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Views;
+using Jellyfin.Sdk;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.ViewModels;
+
+#pragma warning disable CA1812
+internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewModel
+#pragma warning restore CA1812
+{
+    private const int ResultLimit = 100;
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly CardFactory _cardFactory;
+    private readonly CancellableLoad _load = new();
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial string Query { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string ResultsTitle { get; private set; } = string.Empty;
+
+    [ObservableProperty]
+    public partial string? ResultsSubtitle { get; private set; }
+
+    [ObservableProperty]
+    public partial bool ShowEmptyState { get; private set; }
+
+    [ObservableProperty]
+    public partial IReadOnlyList<Card>? Items { get; private set; }
+
+    public SearchViewModel(
+        JellyfinApiClient jellyfinApiClient,
+        CardFactory cardFactory)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+        _cardFactory = cardFactory;
+    }
+
+    public void CancelLoading() => _ = _load.CancelAsync();
+
+    public void HandleParameters(Search.Parameters parameters)
+    {
+        Query = parameters.Query.Trim();
+        ResultsTitle = $"Results for \"{Query}\"";
+        Items = null;
+        ShowEmptyState = false;
+        ResultsSubtitle = null;
+        _ = _load.RunAsync(LoadResultsAsync);
+    }
+
+    private async Task LoadResultsAsync(CancellationToken cancellationToken)
+    {
+        IsLoading = true;
+
+        try
+        {
+            BaseItemDtoQueryResult? result = await _jellyfinApiClient.Items.GetAsync(
+                parameters =>
+                {
+                    parameters.QueryParameters.SearchTerm = Query;
+                    parameters.QueryParameters.IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series];
+                    parameters.QueryParameters.Recursive = true;
+                    parameters.QueryParameters.SortBy = [ItemSortBy.SortName];
+                    parameters.QueryParameters.Limit = ResultLimit;
+                    parameters.QueryParameters.Fields = [ItemFields.PrimaryImageAspectRatio, ItemFields.MediaSourceCount];
+                    parameters.QueryParameters.ImageTypeLimit = 1;
+                    parameters.QueryParameters.EnableImageTypes = [ImageType.Primary, ImageType.Backdrop, ImageType.Banner, ImageType.Thumb];
+                },
+                cancellationToken: cancellationToken);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (result?.Items is null || result.Items.Count == 0)
+            {
+                Items = [];
+                ShowEmptyState = true;
+                ResultsSubtitle = "No movies or TV shows matched your search.";
+                return;
+            }
+
+            List<Card> items = new(result.Items.Count);
+            foreach (BaseItemDto item in result.Items)
+            {
+                if (!item.Id.HasValue)
+                {
+                    continue;
+                }
+
+                if (item.Type is not (BaseItemDto_Type.Movie or BaseItemDto_Type.Series))
+                {
+                    continue;
+                }
+
+                items.Add(_cardFactory.CreateFromItem(item, CardShape.Portrait, preferredImageType: null));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            Items = items;
+            ShowEmptyState = items.Count == 0;
+            ResultsSubtitle = items.Count == 0
+                ? "No movies or TV shows matched your search."
+                : items.Count == 1
+                    ? "1 result"
+                    : $"{items.Count} results";
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer search; leave state for the newer load to populate.
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in SearchViewModel.LoadResultsAsync: {ex}");
+            Items = [];
+            ShowEmptyState = true;
+            ResultsSubtitle = "Something went wrong while searching. Please try again.";
+        }
+        finally
+        {
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                IsLoading = false;
+            }
+        }
+    }
+}

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -1,0 +1,167 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using JellyBox.Models;
+using JellyBox.Services;
+using Jellyfin.Sdk;
+using Jellyfin.Sdk.Generated.Models;
+
+namespace JellyBox.ViewModels;
+
+#pragma warning disable CA1812
+internal sealed partial class ShellSearchViewModel : ObservableObject
+#pragma warning restore CA1812
+{
+    private const int MinimumQueryLength = 2;
+    private const int SuggestionLimit = 8;
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(350);
+
+    private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly NavigationManager _navigationManager;
+    private int _searchVersion;
+    private bool _suppressSuggestions;
+
+    [ObservableProperty]
+    public partial string Query { get; set; } = string.Empty;
+
+    public ObservableCollection<SearchSuggestion> Suggestions { get; } = [];
+
+    public ShellSearchViewModel(
+        JellyfinApiClient jellyfinApiClient,
+        NavigationManager navigationManager)
+    {
+        _jellyfinApiClient = jellyfinApiClient;
+        _navigationManager = navigationManager;
+    }
+
+    partial void OnQueryChanged(string value)
+    {
+        if (!_suppressSuggestions)
+        {
+            _ = UpdateSuggestionsAsync(value);
+        }
+    }
+
+    public void SubmitQuery(string? query)
+    {
+        string trimmed = (query ?? Query).Trim();
+        if (trimmed.Length < MinimumQueryLength)
+        {
+            return;
+        }
+
+        Query = trimmed;
+        _navigationManager.NavigateToSearch(trimmed);
+    }
+
+    public void ClearQuery()
+    {
+        Interlocked.Increment(ref _searchVersion);
+        Query = string.Empty;
+        ReplaceSuggestions([]);
+    }
+
+    public void SelectSuggestion(SearchSuggestion suggestion)
+    {
+        _suppressSuggestions = true;
+        try
+        {
+            Interlocked.Increment(ref _searchVersion);
+            Query = string.Empty;
+            ReplaceSuggestions([]);
+            _navigationManager.NavigateToItem(suggestion.ItemId);
+        }
+        finally
+        {
+            _suppressSuggestions = false;
+        }
+    }
+
+    private async Task UpdateSuggestionsAsync(string query)
+    {
+        int version = Interlocked.Increment(ref _searchVersion);
+
+        string trimmed = query.Trim();
+        if (trimmed.Length < MinimumQueryLength)
+        {
+            ReplaceSuggestions([]);
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(DebounceDelay);
+
+            if (version != _searchVersion)
+            {
+                return;
+            }
+
+            SearchHintResult? result = await _jellyfinApiClient.Search.Hints.GetAsync(
+                parameters =>
+                {
+                    parameters.QueryParameters.SearchTerm = trimmed;
+                    parameters.QueryParameters.IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series];
+                    parameters.QueryParameters.IncludeMedia = true;
+                    parameters.QueryParameters.Limit = SuggestionLimit;
+                });
+
+            if (version != _searchVersion)
+            {
+                return;
+            }
+
+            if (result?.SearchHints is null)
+            {
+                ReplaceSuggestions([]);
+                return;
+            }
+
+            List<SearchSuggestion> suggestions = new(result.SearchHints.Count);
+            foreach (SearchHint hint in result.SearchHints)
+            {
+                SearchSuggestion? suggestion = CreateSuggestion(hint);
+                if (suggestion is not null)
+                {
+                    suggestions.Add(suggestion);
+                }
+            }
+
+            ReplaceSuggestions(suggestions);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error in ShellSearchViewModel.UpdateSuggestionsAsync: {ex}");
+            ReplaceSuggestions([]);
+        }
+    }
+
+    private void ReplaceSuggestions(IEnumerable<SearchSuggestion> suggestions)
+    {
+        Suggestions.Clear();
+        foreach (SearchSuggestion suggestion in suggestions)
+        {
+            Suggestions.Add(suggestion);
+        }
+    }
+
+    private static SearchSuggestion? CreateSuggestion(SearchHint hint)
+    {
+        if (hint.Type is not (SearchHint_Type.Movie or SearchHint_Type.Series))
+        {
+            return null;
+        }
+
+        if (!hint.Id.HasValue || string.IsNullOrWhiteSpace(hint.Name))
+        {
+            return null;
+        }
+
+        string typeLabel = hint.Type == SearchHint_Type.Movie ? "Movie" : "TV Show";
+        string? secondaryText = hint.ProductionYear.HasValue
+            ? $"{typeLabel} · {hint.ProductionYear.Value}"
+            : typeLabel;
+
+        return new SearchSuggestion(hint.Name, secondaryText, hint.Id.Value);
+    }
+}

--- a/src/JellyBox/Views/Home.xaml
+++ b/src/JellyBox/Views/Home.xaml
@@ -20,7 +20,7 @@
                 x:Name="SectionsControl"
                 ItemsSource="{x:Bind ViewModel.Sections, Mode=OneWay}"
                 ItemTemplate="{StaticResource Section}"
-                Margin="0,48,0,48"
+                Margin="0,16,0,48"
                 XYFocusKeyboardNavigation="Enabled">
                 <Interactivity:Interaction.Behaviors>
                     <Behaviors:SectionNavigationBehavior

--- a/src/JellyBox/Views/Home.xaml.cs
+++ b/src/JellyBox/Views/Home.xaml.cs
@@ -19,7 +19,11 @@ internal sealed partial class Home : Page
         SectionsControl.LayoutUpdated += SectionsControl_LayoutUpdated;
     }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.Initialize();
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        _hasFocusedFirstItem = false;
+        ViewModel.Initialize();
+    }
 
     public HomeViewModel ViewModel { get; }
 

--- a/src/JellyBox/Views/ItemDetails.xaml
+++ b/src/JellyBox/Views/ItemDetails.xaml
@@ -63,7 +63,7 @@
             VerticalScrollBarVisibility="Hidden"
             BringIntoViewOnFocusChange="False"
             IsTabStop="False">
-            <Grid x:Name="ContentGrid" XYFocusKeyboardNavigation="Enabled" Margin="48,100,48,48">
+            <Grid x:Name="ContentGrid" XYFocusKeyboardNavigation="Enabled" Margin="48,24,48,48">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="380" />
                     <ColumnDefinition Width="*" />
@@ -250,7 +250,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedSourceContainer.Value.Name, Mode=OneWay}"
+                                    Text="{x:Bind GetSourceContainerName(ViewModel.SelectedSourceContainer), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -285,7 +285,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedSourceContainer.Value.Name, Mode=OneWay}"
+                                Text="{x:Bind GetSourceContainerName(ViewModel.SelectedSourceContainer), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>
@@ -312,7 +312,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedAudioStream.DisplayText, Mode=OneWay}"
+                                    Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedAudioStream), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -347,7 +347,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedAudioStream.DisplayText, Mode=OneWay}"
+                                Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedAudioStream), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>
@@ -374,7 +374,7 @@
                                     VerticalAlignment="Center" />
                                 <TextBlock
                                     Grid.Column="1"
-                                    Text="{x:Bind ViewModel.SelectedSubtitleStream.DisplayText, Mode=OneWay}"
+                                    Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedSubtitleStream), Mode=OneWay}"
                                     VerticalAlignment="Center" />
                                 <FontIcon
                                     Grid.Column="2"
@@ -409,7 +409,7 @@
                                 FontSize="{StaticResource FontS}" />
                             <TextBlock
                                 Grid.Column="1"
-                                Text="{x:Bind ViewModel.SelectedSubtitleStream.DisplayText, Mode=OneWay}"
+                                Text="{x:Bind GetStreamDisplayText(ViewModel.SelectedSubtitleStream), Mode=OneWay}"
                                 Foreground="{StaticResource TextPrimary}"
                                 FontSize="{StaticResource FontS}" />
                         </Grid>

--- a/src/JellyBox/Views/ItemDetails.xaml.cs
+++ b/src/JellyBox/Views/ItemDetails.xaml.cs
@@ -32,7 +32,17 @@ internal sealed partial class ItemDetails : Page
 
     internal ItemDetailsViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        _hasFocusedInitial = false;
+        _lastNavigationDirection = null;
+        ContentInfoPanel.LayoutUpdated -= ContentInfoPanel_LayoutUpdated;
+        ContentInfoPanel.LayoutUpdated += ContentInfoPanel_LayoutUpdated;
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+    }
+
+    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        => ViewModel.CancelLoading();
 
     internal sealed record Parameters(Guid ItemId);
 
@@ -233,6 +243,16 @@ internal sealed partial class ItemDetails : Page
     private Style GetPlayButtonStyle(bool canResume)
 #pragma warning restore CA1822
         => (Style)Application.Current.Resources[canResume ? "SecondaryButton" : "PrimaryButton"];
+
+#pragma warning disable CA1822 // Used by x:Bind
+    private string GetSourceContainerName(MediaSourceInfoWrapper? source)
+#pragma warning restore CA1822
+        => source?.Value?.Name ?? string.Empty;
+
+#pragma warning disable CA1822 // Used by x:Bind
+    private string GetStreamDisplayText(MediaStreamOption? stream)
+#pragma warning restore CA1822
+        => stream?.DisplayText ?? string.Empty;
 
     private bool IsActionButton(object? element)
         => ReferenceEquals(element, ResumeButton)

--- a/src/JellyBox/Views/Library.xaml
+++ b/src/JellyBox/Views/Library.xaml
@@ -18,7 +18,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header: Title + Toolbar -->
-        <StackPanel Grid.Row="0" Padding="48,24,48,0">
+        <StackPanel Grid.Row="0" Padding="48,16,48,0">
             <TextBlock
                 Text="{x:Bind ViewModel.Title, Mode=OneWay}"
                 FontSize="{StaticResource FontXL}"
@@ -101,12 +101,11 @@
                     x:Name="FilterButton"
                     Background="{StaticResource BackgroundElevated}"
                     Foreground="{StaticResource TextPrimary}"
-                    BorderBrush="{x:Bind viewmodels:LibraryViewModel.GetFilterBorderBrush(ViewModel.HasActiveFilters), Mode=OneWay}"
+                    BorderBrush="{StaticResource BorderSubtle}"
                     BorderThickness="1"
                     Padding="16,8"
                     CornerRadius="4"
-                    XYFocusKeyboardNavigation="Enabled"
-                    XYFocusRight="{x:Bind viewmodels:LibraryViewModel.GetFilterXYFocusRight(ViewModel.HasActiveFilters, FilterButton, ClearFiltersButton), Mode=OneWay}">
+                    XYFocusKeyboardNavigation="Enabled">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontFamily="{StaticResource SegoeIcons}" Glyph="&#xE71C;" FontSize="16" />
                         <TextBlock Text="Filter" FontSize="{StaticResource FontS}" />
@@ -176,8 +175,7 @@
                     Foreground="{StaticResource AccentColor}"
                     BorderThickness="0"
                     Padding="12,8"
-                    CornerRadius="4"
-                    XYFocusRight="{x:Bind ClearFiltersButton}">
+                    CornerRadius="4">
                     <StackPanel Orientation="Horizontal" Spacing="6">
                         <FontIcon FontFamily="{StaticResource SegoeIcons}" Glyph="&#xE711;" FontSize="12" />
                         <TextBlock Text="Clear Filters" FontSize="{StaticResource FontS}" />

--- a/src/JellyBox/Views/Library.xaml.cs
+++ b/src/JellyBox/Views/Library.xaml.cs
@@ -1,6 +1,8 @@
+using System.ComponentModel;
 using JellyBox.ViewModels;
 using Jellyfin.Sdk.Generated.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -8,15 +10,57 @@ namespace JellyBox.Views;
 
 internal sealed partial class Library : Page
 {
+    private bool _filterChromeAttached;
+
     public Library()
     {
         InitializeComponent();
         ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<LibraryViewModel>();
+        Loaded += OnLoaded;
     }
 
     internal LibraryViewModel ViewModel { get; }
 
-    protected override void OnNavigatedTo(NavigationEventArgs e) => ViewModel.HandleParameters((Parameters)e.Parameter);
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        ViewModel.HandleParameters((Parameters)e.Parameter);
+        UpdateFilterChrome();
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (_filterChromeAttached)
+        {
+            return;
+        }
+
+        _filterChromeAttached = true;
+        ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        UpdateFilterChrome();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(LibraryViewModel.HasActiveFilters))
+        {
+            UpdateFilterChrome();
+        }
+    }
+
+    private void UpdateFilterChrome()
+    {
+        if (!IsLoaded)
+        {
+            return;
+        }
+
+        FilterButton.BorderBrush = LibraryViewModel.GetFilterBorderBrush(ViewModel.HasActiveFilters);
+        FilterButton.XYFocusRight = LibraryViewModel.GetFilterXYFocusRight(
+            ViewModel.HasActiveFilters,
+            FilterButton,
+            ClearFiltersButton);
+        ClearFiltersButton.XYFocusRight = ClearFiltersButton;
+    }
 
     private void SortListView_ItemClick(object sender, ItemClickEventArgs e)
     {

--- a/src/JellyBox/Views/Search.xaml
+++ b/src/JellyBox/Views/Search.xaml
@@ -1,0 +1,62 @@
+<Page
+    x:Class="JellyBox.Views.Search"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Behaviors="using:JellyBox.Behaviors"
+    xmlns:controls="using:JellyBox.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{StaticResource BackgroundBase}">
+
+    <Grid XYFocusKeyboardNavigation="Enabled">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Padding="48,16,48,8" Spacing="4">
+            <TextBlock
+                Text="{x:Bind ViewModel.ResultsTitle, Mode=OneWay}"
+                FontSize="{StaticResource FontXL}"
+                FontWeight="SemiBold"
+                Foreground="{StaticResource TextPrimary}" />
+            <TextBlock
+                Text="{x:Bind ViewModel.ResultsSubtitle, Mode=OneWay}"
+                FontSize="{StaticResource FontS}"
+                Foreground="{StaticResource TextMuted}" />
+        </StackPanel>
+
+        <GridView
+            Grid.Row="1"
+            Padding="48,8,48,48"
+            ItemsSource="{x:Bind ViewModel.Items, Mode=OneWay}"
+            ItemTemplate="{StaticResource Card}"
+            ItemContainerStyle="{StaticResource CardGridViewItemStyle}"
+            SelectionMode="None"
+            IsItemClickEnabled="True"
+            SingleSelectionFollowsFocus="False"
+            TabNavigation="Once"
+            IsTabStop="False"
+            XYFocusKeyboardNavigation="Enabled"
+            ScrollViewer.VerticalScrollBarVisibility="Hidden"
+            ScrollViewer.VerticalScrollMode="Enabled"
+            ScrollViewer.HorizontalScrollMode="Disabled"
+            ScrollViewer.BringIntoViewOnFocusChange="False"
+            Visibility="{x:Bind ViewModel.ShowEmptyState, Mode=OneWay, Converter={StaticResource NegateConverter}}">
+            <Interactivity:Interaction.Behaviors>
+                <Behaviors:FocusFirstItemBehavior />
+                <Behaviors:ListViewBaseCommandBehavior />
+                <Behaviors:ScrollOnFocusBehavior SafeZoneMargin="48" EnableVerticalScroll="True" TrapFocusAtRightEdge="False" TopOffset="100" />
+            </Interactivity:Interaction.Behaviors>
+            <GridView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsWrapGrid Orientation="Horizontal" HorizontalAlignment="Center" />
+                </ItemsPanelTemplate>
+            </GridView.ItemsPanel>
+        </GridView>
+
+        <controls:LoadingOverlay Grid.Row="1" Visibility="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+    </Grid>
+</Page>

--- a/src/JellyBox/Views/Search.xaml.cs
+++ b/src/JellyBox/Views/Search.xaml.cs
@@ -1,0 +1,25 @@
+using JellyBox.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace JellyBox.Views;
+
+internal sealed partial class Search : Page
+{
+    public Search()
+    {
+        InitializeComponent();
+        ViewModel = AppServices.Instance.ServiceProvider.GetRequiredService<SearchViewModel>();
+    }
+
+    internal SearchViewModel ViewModel { get; }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+        => ViewModel.HandleParameters((Parameters)e.Parameter);
+
+    protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        => ViewModel.CancelLoading();
+
+    internal sealed record Parameters(string Query);
+}

--- a/src/JellyBox/Views/Video.xaml.cs
+++ b/src/JellyBox/Views/Video.xaml.cs
@@ -71,20 +71,14 @@ internal sealed partial class Video : Page
                 }
                 break;
 
-            // Controller: A, Keyboard: Space/K - Play/Pause (when transport controls are not focused)
+            // Controller: A / Menu, Keyboard: Space/K - Play/Pause
             case VirtualKey.GamepadA:
-                if (!hasControlFocus)
+            case VirtualKey.GamepadMenu:
+                if (!hasControlFocus || key is VirtualKey.GamepadMenu)
                 {
                     ViewModel.TogglePlayPause();
                     args.Handled = true;
                 }
-
-                break;
-
-            // Controller: Menu - Play/Pause globally
-            case VirtualKey.GamepadMenu:
-                ViewModel.TogglePlayPause();
-                args.Handled = true;
                 break;
 
             case VirtualKey.Space:


### PR DESCRIPTION
## What & why

Bugfix for a search panel. Pressing "B" to dismiss the on-screen keyboard while shell search suggestions are open navigated to the first result automatically. Had to suppress those dismiss events so the user can browse suggestions with the d-pad and confirm with "A".

**Merge after #98.** Review commit `387bdeb` only (`MainPage.xaml`, `MainPage.xaml.cs`).

## Out of scope

Shell search implementation is in #98.
Fully tested on XBSX