### PR TITLE
Add file-based logging foundation

### DIFF
--- a/src/JellyBox/App.xaml.cs
+++ b/src/JellyBox/App.xaml.cs
@@ -2,6 +2,7 @@
 using JellyBox.Views;
 using Jellyfin.Sdk;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
@@ -20,6 +21,7 @@ namespace JellyBox;
 sealed partial class App : Application
 #pragma warning restore CA1515 // Consider making public types internal
 {
+    private readonly ILogger _logger;
     private readonly AppSettings _appSettings;
     private readonly JellyfinSdkSettings _sdkClientSettings;
     private readonly NavigationManager _navigationManager;
@@ -33,6 +35,7 @@ sealed partial class App : Application
     {
         ConfigureWebView2();
 
+        _logger = AppServices.Instance.ServiceProvider.GetRequiredService<ILogger<App>>();
         _appSettings = AppServices.Instance.ServiceProvider.GetRequiredService<AppSettings>();
         _sdkClientSettings = AppServices.Instance.ServiceProvider.GetRequiredService<JellyfinSdkSettings>();
         _navigationManager = AppServices.Instance.ServiceProvider.GetRequiredService<NavigationManager>();
@@ -41,6 +44,7 @@ sealed partial class App : Application
         InitializeComponent();
 
         UnhandledException += OnUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
         Current.RequiresPointerMode = ApplicationRequiresPointerMode.WhenRequested;
 
@@ -49,17 +53,31 @@ sealed partial class App : Application
 
     private void OnUnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs e)
     {
-        System.Diagnostics.Debug.WriteLine($"Unhandled UI exception: {e.Exception}");
-        if (e.Exception.InnerException is not null)
-        {
-            System.Diagnostics.Debug.WriteLine($"Inner exception: {e.Exception.InnerException}");
-        }
+        LogUnhandledException(e.Exception);
+        FlushLogs();
     }
+
+    private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        LogUnobservedTaskException(e.Exception);
+        FlushLogs();
+
+        // Prevent the process from terminating on unobserved task exceptions.
+        e.SetObserved();
+    }
+
+    // Drain the file logger synchronously so the latest entries survive a crash or suspension.
+    private static void FlushLogs()
+        => AppServices.Instance.ServiceProvider
+            .GetRequiredService<FileLoggerProvider>()
+            .Flush(TimeSpan.FromSeconds(2));
 
     /// <inheritdoc/>
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
         ArgumentNullException.ThrowIfNull(args);
+
+        LogApplicationLaunched(args.PreviousExecutionState);
 
         Frame? rootFrame = Window.Current.Content as Frame;
 
@@ -141,7 +159,7 @@ sealed partial class App : Application
         catch (Exception ex)
         {
             // Log initialization failure but don't crash the app - playback will handle missing profile gracefully
-            System.Diagnostics.Debug.WriteLine($"Failed to initialize device profile: {ex}");
+            LogDeviceProfileInitializationFailed(ex);
         }
     }
 
@@ -168,7 +186,10 @@ sealed partial class App : Application
     {
         SuspendingDeferral deferral = e.SuspendingOperation.GetDeferral();
 
+        LogApplicationSuspending();
+
         // TODO: Save application state and stop any background activity
+        FlushLogs();
         deferral.Complete();
     }
 
@@ -180,4 +201,19 @@ sealed partial class App : Application
         // Avoid flashbang before loading the uri by setting the default background color to be transparent.
         Environment.SetEnvironmentVariable("WEBVIEW2_DEFAULT_BACKGROUND_COLOR", "00FFFFFF");
     }
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Unhandled exception.")]
+    private partial void LogUnhandledException(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unobserved task exception.")]
+    private partial void LogUnobservedTaskException(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to initialize device profile.")]
+    private partial void LogDeviceProfileInitializationFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Application launched (previous execution state: {PreviousExecutionState}).")]
+    private partial void LogApplicationLaunched(ApplicationExecutionState previousExecutionState);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Application suspending.")]
+    private partial void LogApplicationSuspending();
 }

--- a/src/JellyBox/AppServices.cs
+++ b/src/JellyBox/AppServices.cs
@@ -32,13 +32,16 @@ internal sealed class AppServices
 
         serviceCollection.AddLogging(builder =>
         {
-            // TODO: Set up better logging
             builder.AddSimpleConsole(options =>
             {
                 options.IncludeScopes = true;
                 options.SingleLine = true;
                 options.TimestampFormat = "HH:mm:ss ";
             });
+
+            // Persist logs to a file under the app's local data folder so they survive on a
+            // sideloaded Xbox/UWP install where console output isn't available.
+            builder.AddFileLogger();
         });
 
         serviceCollection.AddHttpClient(

--- a/src/JellyBox/Services/FileLoggerProvider.cs
+++ b/src/JellyBox/Services/FileLoggerProvider.cs
@@ -1,0 +1,322 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Windows.Storage;
+
+namespace JellyBox.Services;
+
+/// <summary>
+/// An <see cref="ILoggerProvider"/> that writes log entries to a rotating file under the app's
+/// local data folder. This persists logs on a sideloaded UWP/Xbox install where console and debug
+/// output is unavailable; the files can be retrieved from a dev console via Device Portal
+/// (LocalState\logs).
+/// </summary>
+/// <remarks>
+/// Entries are handed to a single background writer thread. Enqueuing is non-blocking: entries are
+/// dropped rather than stalling app threads when the bounded queue is full. <see cref="Flush"/>
+/// provides a bounded synchronous drain for crash and suspend paths, where losing the most recent
+/// entries would defeat the purpose of logging them.
+/// </remarks>
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. Used via dependency injection.
+internal sealed class FileLoggerProvider : ILoggerProvider
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
+{
+    private const long MaxLogFileSizeBytes = 4L * 1024 * 1024;
+    private const int MaxRetainedFiles = 3;
+    private const int MaxQueuedEntries = 1024;
+
+    private readonly string _logDirectory;
+    private readonly string _logFilePath;
+    private readonly BlockingCollection<LogItem> _queue = new(MaxQueuedEntries);
+    private readonly Thread _writerThread;
+    private bool _disposed;
+
+    public FileLoggerProvider()
+    {
+        _logDirectory = Path.Combine(ApplicationData.Current.LocalFolder.Path, "logs");
+        _logFilePath = Path.Combine(_logDirectory, "jellybox.log");
+
+        _writerThread = new Thread(ProcessQueue)
+        {
+            IsBackground = true,
+            Name = "FileLoggerWriter",
+        };
+        _writerThread.Start();
+    }
+
+    public ILogger CreateLogger(string categoryName)
+        => new FileLogger(categoryName, line => Enqueue(new LogItem(line, null)));
+
+    /// <summary>
+    /// Blocks until entries enqueued before this call are written to disk, or until the timeout
+    /// elapses. Intended for crash and suspend handlers so the latest entries are persisted.
+    /// </summary>
+    public void Flush(TimeSpan timeout)
+    {
+        if (!_writerThread.IsAlive || _queue.IsAddingCompleted)
+        {
+            return;
+        }
+
+        long startMilliseconds = Environment.TickCount64;
+        using ManualResetEventSlim signal = new(initialState: false);
+
+        // Enqueue the flush marker with a bounded wait so a momentarily full queue can't cause
+        // Flush to no-op and drop the very entries a crash/suspend needs persisted. The writer is
+        // actively draining, so a slot frees up quickly.
+        if (!TryAddWithTimeout(new LogItem(null, signal), timeout))
+        {
+            return;
+        }
+
+        TimeSpan remaining = timeout - TimeSpan.FromMilliseconds(Environment.TickCount64 - startMilliseconds);
+        if (remaining > TimeSpan.Zero)
+        {
+            signal.Wait(remaining);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _queue.CompleteAdding();
+        if (!_writerThread.Join(TimeSpan.FromSeconds(2)))
+        {
+            System.Diagnostics.Debug.WriteLine("FileLogger: writer thread did not flush within timeout.");
+        }
+
+        _queue.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private bool Enqueue(LogItem item)
+    {
+        try
+        {
+            // Non-blocking: drop the entry when the queue is full so logging never stalls a caller.
+            return _queue.TryAdd(item);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Provider was disposed concurrently.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // Adding was completed on another thread during shutdown.
+            return false;
+        }
+    }
+
+    private bool TryAddWithTimeout(LogItem item, TimeSpan timeout)
+    {
+        try
+        {
+            return _queue.TryAdd(item, timeout);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Provider was disposed concurrently.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // Adding was completed on another thread during shutdown.
+            return false;
+        }
+    }
+
+    private void ProcessQueue()
+    {
+        try
+        {
+            Directory.CreateDirectory(_logDirectory);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"FileLogger: failed to create log directory: {ex}");
+
+            // Keep draining so enqueuers never block on a full queue and flush waiters are released.
+            foreach (LogItem item in _queue.GetConsumingEnumerable())
+            {
+                Release(item.FlushSignal);
+            }
+
+            return;
+        }
+
+        foreach (LogItem item in _queue.GetConsumingEnumerable())
+        {
+            if (item.FlushSignal is not null)
+            {
+                Release(item.FlushSignal);
+                continue;
+            }
+
+            try
+            {
+                RollIfNeeded();
+                File.AppendAllText(_logFilePath, item.Line + Environment.NewLine, Encoding.UTF8);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"FileLogger: failed to write log entry: {ex}");
+            }
+        }
+    }
+
+    private static void Release(ManualResetEventSlim? signal)
+    {
+        try
+        {
+            signal?.Set();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The waiter timed out and disposed the signal; nothing to release.
+        }
+    }
+
+    private void RollIfNeeded()
+    {
+        FileInfo fileInfo = new(_logFilePath);
+        if (!fileInfo.Exists || fileInfo.Length < MaxLogFileSizeBytes)
+        {
+            return;
+        }
+
+        string oldest = FormattableString.Invariant($"{_logFilePath}.{MaxRetainedFiles}");
+        if (File.Exists(oldest))
+        {
+            File.Delete(oldest);
+        }
+
+        for (int i = MaxRetainedFiles - 1; i >= 1; i--)
+        {
+            string source = FormattableString.Invariant($"{_logFilePath}.{i}");
+            if (File.Exists(source))
+            {
+                File.Move(source, FormattableString.Invariant($"{_logFilePath}.{i + 1}"));
+            }
+        }
+
+        File.Move(_logFilePath, FormattableString.Invariant($"{_logFilePath}.1"));
+    }
+
+    /// <summary>A queued log line, or a flush marker that signals when prior entries are written.</summary>
+    private sealed class LogItem
+    {
+        public LogItem(string? line, ManualResetEventSlim? flushSignal)
+        {
+            Line = line;
+            FlushSignal = flushSignal;
+        }
+
+        public string? Line { get; }
+
+        public ManualResetEventSlim? FlushSignal { get; }
+    }
+}
+
+/// <summary>
+/// Formats log entries and hands them to the owning <see cref="FileLoggerProvider"/>'s writer.
+/// </summary>
+internal sealed class FileLogger : ILogger
+{
+    private readonly string _categoryName;
+    private readonly Action<string> _enqueue;
+
+    public FileLogger(string categoryName, Action<string> enqueue)
+    {
+        _categoryName = categoryName;
+        _enqueue = enqueue;
+    }
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull
+        => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        string message = formatter(state, exception);
+
+        StringBuilder builder = new();
+        builder.Append(CultureInfo.InvariantCulture, $"{DateTimeOffset.Now:yyyy-MM-dd HH:mm:ss.fff zzz} [{GetLevelLabel(logLevel)}] {_categoryName}");
+        if (eventId.Id != 0)
+        {
+            builder.Append(CultureInfo.InvariantCulture, $" ({eventId.Id})");
+        }
+
+        builder.Append(": ").Append(message);
+
+        if (exception is not null)
+        {
+            builder.Append(Environment.NewLine).Append(exception);
+        }
+
+        _enqueue(builder.ToString());
+    }
+
+    private static string GetLevelLabel(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Trace => "trce",
+        LogLevel.Debug => "dbug",
+        LogLevel.Information => "info",
+        LogLevel.Warning => "warn",
+        LogLevel.Error => "fail",
+        LogLevel.Critical => "crit",
+        _ => "none",
+    };
+}
+
+/// <summary>
+/// A no-op scope returned by <see cref="FileLogger.BeginScope{TState}(TState)"/>.
+/// </summary>
+internal sealed class NullScope : IDisposable
+{
+    public static NullScope Instance { get; } = new();
+
+    private NullScope()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+internal static class FileLoggerBuilderExtensions
+{
+    public static ILoggingBuilder AddFileLogger(this ILoggingBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Register the concrete provider so crash/suspend handlers can resolve it to flush,
+        // and expose the same instance to the logging factory as an ILoggerProvider.
+        builder.Services.TryAddSingleton<FileLoggerProvider>();
+        builder.Services.AddSingleton<ILoggerProvider>(static sp => sp.GetRequiredService<FileLoggerProvider>());
+        return builder;
+    }
+}

--- a/src/JellyBox/Services/NavigationManager.cs
+++ b/src/JellyBox/Services/NavigationManager.cs
@@ -1,7 +1,7 @@
-using System.Diagnostics;
 using JellyBox.Views;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
 using Windows.System;
@@ -14,7 +14,7 @@ using Windows.UI.Xaml.Input;
 namespace JellyBox.Services;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes. Used via dependency injection.
-internal sealed class NavigationManager
+internal sealed partial class NavigationManager
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
 {
     // Fake item id used to identify the home page
@@ -47,9 +47,11 @@ internal sealed class NavigationManager
     private object? _currentContentParameter;
 
     private readonly JellyfinApiClient _jellyfinApiClient;
+    private readonly ILogger<NavigationManager> _logger;
 
-    public NavigationManager(JellyfinApiClient jellyfinApiClient)
+    public NavigationManager(ILogger<NavigationManager> logger, JellyfinApiClient jellyfinApiClient)
     {
+        _logger = logger;
         _jellyfinApiClient = jellyfinApiClient;
     }
 
@@ -148,7 +150,7 @@ internal sealed class NavigationManager
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in NavigationManager.NavigateToItemAsync: {ex}");
+            LogNavigateToItemFailed(ex, itemId);
         }
     }
 
@@ -208,7 +210,7 @@ internal sealed class NavigationManager
         }
     }
 
-    private static void NavigateFrame<TPage>(Frame frame, ref object? currentParameter, object? parameter = null)
+    private void NavigateFrame<TPage>(Frame frame, ref object? currentParameter, object? parameter = null)
     {
         // Only navigate if the selected page isn't currently loaded with the same parameter.
         Type pageType = typeof(TPage);
@@ -217,6 +219,7 @@ internal sealed class NavigationManager
             return;
         }
 
+        LogNavigating(pageType.Name);
         currentParameter = parameter;
         frame.Navigate(pageType, parameter);
     }
@@ -401,4 +404,10 @@ internal sealed class NavigationManager
             }
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Navigating to {PageType}.")]
+    private partial void LogNavigating(string pageType);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to navigate to item {ItemId}.")]
+    private partial void LogNavigateToItemFailed(Exception exception, Guid itemId);
 }

--- a/src/JellyBox/ViewModels/HomeViewModel.cs
+++ b/src/JellyBox/ViewModels/HomeViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using JellyBox.Models;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 
 namespace JellyBox.ViewModels;
 
@@ -9,6 +10,7 @@ namespace JellyBox.ViewModels;
 internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewModel
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
+    private readonly ILogger<HomeViewModel> _logger;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly CardFactory _cardFactory;
     private readonly CancellableLoad _load = new();
@@ -20,9 +22,11 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
     public partial IReadOnlyList<Section>? Sections { get; set; }
 
     public HomeViewModel(
+        ILogger<HomeViewModel> logger,
         JellyfinApiClient jellyfinApiClient,
         CardFactory cardFactory)
     {
+        _logger = logger;
         _jellyfinApiClient = jellyfinApiClient;
         _cardFactory = cardFactory;
     }
@@ -65,7 +69,7 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in HomeViewModel.Initialize: {ex}");
+            LogLoadFailed(ex);
         }
         finally
         {
@@ -131,4 +135,7 @@ internal sealed partial class HomeViewModel : ObservableObject, ILoadingViewMode
             Cards = cards,
         };
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to load home sections.")]
+    private partial void LogLoadFailed(Exception exception);
 }

--- a/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
+++ b/src/JellyBox/ViewModels/ItemDetailsViewModel.cs
@@ -8,6 +8,7 @@ using JellyBox.Services;
 using JellyBox.Views;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 
 namespace JellyBox.ViewModels;
 
@@ -24,6 +25,7 @@ internal sealed record MediaSourceInfoWrapper(string DisplayText, MediaSourceInf
 internal sealed partial class ItemDetailsViewModel : ObservableObject
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
+    private readonly ILogger<ItemDetailsViewModel> _logger;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly JellyfinImageResolver _imageResolver;
     private readonly NavigationManager _navigationManager;
@@ -133,11 +135,13 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
     public partial bool HasTrailer { get; set; }
 
     public ItemDetailsViewModel(
+        ILogger<ItemDetailsViewModel> logger,
         JellyfinApiClient jellyfinApiClient,
         JellyfinImageResolver imageResolver,
         NavigationManager navigationManager,
         CardFactory cardFactory)
     {
+        _logger = logger;
         _jellyfinApiClient = jellyfinApiClient;
         _imageResolver = imageResolver;
         _navigationManager = navigationManager;
@@ -273,7 +277,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in ItemDetailsViewModel.LoadAsync: {ex}");
+            LogLoadFailed(ex);
         }
     }
 
@@ -292,7 +296,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in OnSelectedSourceContainerChanged: {ex}");
+            LogSourceOptionsFailed(ex);
         }
     }
 
@@ -505,7 +509,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in PlayTrailer: {ex}");
+            LogPlayTrailerFailed(ex);
         }
     }
 
@@ -525,7 +529,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in TogglePlayed: {ex}");
+            LogTogglePlayedFailed(ex);
         }
     }
 
@@ -545,7 +549,7 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error in ToggleFavorite: {ex}");
+            LogToggleFavoriteFailed(ex);
         }
     }
 
@@ -891,4 +895,19 @@ internal sealed partial class ItemDetailsViewModel : ObservableObject
             static int Compare(bool x, bool y) => (x ? 1 : 0) - (y ? 1 : 0);
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to load item details.")]
+    private partial void LogLoadFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update media source options.")]
+    private partial void LogSourceOptionsFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to play trailer.")]
+    private partial void LogPlayTrailerFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to toggle played state.")]
+    private partial void LogTogglePlayedFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to toggle favorite state.")]
+    private partial void LogToggleFavoriteFailed(Exception exception);
 }

--- a/src/JellyBox/ViewModels/LibraryViewModel.Filtering.cs
+++ b/src/JellyBox/ViewModels/LibraryViewModel.Filtering.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Jellyfin.Sdk.Generated.Models;
@@ -168,7 +167,7 @@ internal sealed partial class LibraryViewModel
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error loading filter values: {ex}");
+            LogFilterValuesFailed(ex);
         }
     }
 

--- a/src/JellyBox/ViewModels/LibraryViewModel.cs
+++ b/src/JellyBox/ViewModels/LibraryViewModel.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using JellyBox.Models;
 using JellyBox.Views;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 
 namespace JellyBox.ViewModels;
 
@@ -11,6 +11,7 @@ namespace JellyBox.ViewModels;
 internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewModel
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
+    private readonly ILogger<LibraryViewModel> _logger;
     private readonly AppSettings _appSettings;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly CardFactory _cardFactory;
@@ -31,10 +32,12 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
     public partial IReadOnlyList<Card>? Items { get; set; }
 
     public LibraryViewModel(
+        ILogger<LibraryViewModel> logger,
         AppSettings appSettings,
         JellyfinApiClient jellyfinApiClient,
         CardFactory cardFactory)
     {
+        _logger = logger;
         _appSettings = appSettings;
         _jellyfinApiClient = jellyfinApiClient;
         _cardFactory = cardFactory;
@@ -82,7 +85,7 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in LibraryViewModel.InitializeAsync: {ex}");
+            LogInitializeFailed(ex);
         }
         finally
         {
@@ -113,7 +116,7 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in LibraryViewModel.RefreshAsync: {ex}");
+            LogRefreshFailed(ex);
         }
         finally
         {
@@ -210,4 +213,13 @@ internal sealed partial class LibraryViewModel : ObservableObject, ILoadingViewM
         static string[] GetSelectedLabels(List<FilterItem> filters)
             => [.. filters.Where(f => f.IsSelected).Select(f => f.Label)];
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to initialize library.")]
+    private partial void LogInitializeFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to refresh library.")]
+    private partial void LogRefreshFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to load library filter values.")]
+    private partial void LogFilterValuesFailed(Exception exception);
 }

--- a/src/JellyBox/ViewModels/LoginViewModel.cs
+++ b/src/JellyBox/ViewModels/LoginViewModel.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using JellyBox.Services;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 using Windows.ApplicationModel.Core;
 using Windows.System.Threading;
 using Windows.UI.Core;
@@ -17,6 +17,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
 {
     private static readonly TimeSpan QuickConnectPollingInterval = TimeSpan.FromSeconds(5);
 
+    private readonly ILogger<LoginViewModel> _logger;
     private readonly AppSettings _appSettings;
     private readonly JellyfinSdkSettings _sdkClientSettings;
     private readonly JellyfinApiClient _jellyfinApiClient;
@@ -43,11 +44,13 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
     public partial string Password { get; set; } = string.Empty;
 
     public LoginViewModel(
+        ILogger<LoginViewModel> logger,
         AppSettings appSettings,
         JellyfinSdkSettings sdkClientSettings,
         JellyfinApiClient jellyfinApiClient,
         NavigationManager navigationManager)
     {
+        _logger = logger;
         _appSettings = appSettings;
         _sdkClientSettings = sdkClientSettings;
         _jellyfinApiClient = jellyfinApiClient;
@@ -69,7 +72,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in LoginViewModel.Initialize: {ex}");
+            LogQuickConnectAvailabilityFailed(ex);
         }
     }
 
@@ -93,7 +96,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
                 return;
             }
 
-            Console.WriteLine($"Logging into {_sdkClientSettings.ServerUrl}");
+            LogSigningIn(_sdkClientSettings.ServerUrl);
 
             AuthenticateUserByName request = new()
             {
@@ -106,7 +109,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Login failed: {ex}");
+            LogSignInFailed(ex);
             UpdateErrorMessage(GetFriendlyErrorMessage(ex));
             return;
         }
@@ -178,7 +181,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
                 {
                     // Timer callbacks with async void can crash the app if exceptions propagate.
                     // Log and suppress to prevent app termination.
-                    Debug.WriteLine($"Error in PollQuickConnectAsync: {ex}");
+                    LogQuickConnectPollFailed(ex);
                 }
             }
 
@@ -186,7 +189,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Quick Connect failed: {ex}");
+            LogQuickConnectFailed(ex);
             UpdateErrorMessage(GetFriendlyErrorMessage(ex));
             return;
         }
@@ -208,6 +211,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
         string? accessToken = authenticationResult?.AccessToken;
         if (accessToken is null)
         {
+            LogAuthenticationFailed();
             UpdateErrorMessage("Authentication failed. Please try again.");
             return false;
         }
@@ -217,7 +221,7 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
 
         _sdkClientSettings.SetAccessToken(accessToken);
 
-        Console.WriteLine("Authentication success.");
+        LogAuthenticationSucceeded();
 
         _navigationManager.NavigateToHome();
 
@@ -240,4 +244,25 @@ internal sealed partial class LoginViewModel : ObservableObject, IDisposable
             TaskCanceledException => "The request timed out. Please try again.",
             _ => "An error occurred during login. Please try again.",
         };
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Signing in to {ServerUrl}.")]
+    private partial void LogSigningIn(string? serverUrl);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Authentication succeeded.")]
+    private partial void LogAuthenticationSucceeded();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Authentication failed: no access token returned.")]
+    private partial void LogAuthenticationFailed();
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to sign in.")]
+    private partial void LogSignInFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to determine Quick Connect availability.")]
+    private partial void LogQuickConnectAvailabilityFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to poll Quick Connect status.")]
+    private partial void LogQuickConnectPollFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to sign in with Quick Connect.")]
+    private partial void LogQuickConnectFailed(Exception exception);
 }

--- a/src/JellyBox/ViewModels/SearchViewModel.cs
+++ b/src/JellyBox/ViewModels/SearchViewModel.cs
@@ -1,9 +1,9 @@
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using JellyBox.Models;
 using JellyBox.Views;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 
 namespace JellyBox.ViewModels;
 
@@ -13,6 +13,7 @@ internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewMo
 {
     private const int ResultLimit = 100;
 
+    private readonly ILogger<SearchViewModel> _logger;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly CardFactory _cardFactory;
     private readonly CancellableLoad _load = new();
@@ -36,9 +37,11 @@ internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewMo
     public partial IReadOnlyList<Card>? Items { get; private set; }
 
     public SearchViewModel(
+        ILogger<SearchViewModel> logger,
         JellyfinApiClient jellyfinApiClient,
         CardFactory cardFactory)
     {
+        _logger = logger;
         _jellyfinApiClient = jellyfinApiClient;
         _cardFactory = cardFactory;
     }
@@ -116,7 +119,7 @@ internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewMo
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in SearchViewModel.LoadResultsAsync: {ex}");
+            LogLoadResultsFailed(ex);
             Items = [];
             ShowEmptyState = true;
             ResultsSubtitle = "Something went wrong while searching. Please try again.";
@@ -129,4 +132,7 @@ internal sealed partial class SearchViewModel : ObservableObject, ILoadingViewMo
             }
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to load search results.")]
+    private partial void LogLoadResultsFailed(Exception exception);
 }

--- a/src/JellyBox/ViewModels/ServerSelectionViewModel.cs
+++ b/src/JellyBox/ViewModels/ServerSelectionViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using JellyBox.Services;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 
 namespace JellyBox.ViewModels;
 
@@ -10,6 +11,7 @@ namespace JellyBox.ViewModels;
 internal sealed partial class ServerSelectionViewModel : ObservableObject
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
+    private readonly ILogger<ServerSelectionViewModel> _logger;
     private readonly AppSettings _appSettings;
     private readonly JellyfinSdkSettings _sdkClientSettings;
     private readonly JellyfinApiClient _jellyfinApiClient;
@@ -25,11 +27,13 @@ internal sealed partial class ServerSelectionViewModel : ObservableObject
     public partial string ServerUrl { get; set; } = string.Empty;
 
     public ServerSelectionViewModel(
+        ILogger<ServerSelectionViewModel> logger,
         AppSettings appSettings,
         JellyfinSdkSettings sdkClientSettings,
         JellyfinApiClient jellyfinApiClient,
         NavigationManager navigationManager)
     {
+        _logger = logger;
         _appSettings = appSettings;
         _sdkClientSettings = sdkClientSettings;
         _jellyfinApiClient = jellyfinApiClient;
@@ -73,16 +77,12 @@ internal sealed partial class ServerSelectionViewModel : ObservableObject
         {
             // Get public system info to verify that the URL points to a Jellyfin server.
             PublicSystemInfo? systemInfo = await _jellyfinApiClient.System.Info.Public.GetAsync();
-            Console.WriteLine($"Connected to {serverUrl}");
-            Console.WriteLine($"Server Name: {systemInfo?.ServerName}");
-            Console.WriteLine($"Server Version: {systemInfo?.Version}");
+            LogConnectedToServer(serverUrl, systemInfo?.ServerName, systemInfo?.Version);
         }
         catch (Exception ex)
         {
             UpdateErrorMessage("We're unable to connect to the selected server right now. Please ensure it is running and try again.");
-#pragma warning disable CA1849 // Call async methods when in an async method
-            Console.Error.WriteLine($"Error connecting to {serverUrl}: {ex.Message}");
-#pragma warning restore CA1849 // Call async methods when in an async method
+            LogServerConnectionFailed(ex, serverUrl);
             return;
         }
 
@@ -101,4 +101,10 @@ internal sealed partial class ServerSelectionViewModel : ObservableObject
         ShowErrorMessage = true;
         ErrorMessage = message;
     }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Connected to server {ServerUrl} (Name: {ServerName}, Version: {ServerVersion}).")]
+    private partial void LogConnectedToServer(string serverUrl, string? serverName, string? serverVersion);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to connect to server {ServerUrl}.")]
+    private partial void LogServerConnectionFailed(Exception exception, string serverUrl);
 }

--- a/src/JellyBox/ViewModels/ShellSearchViewModel.cs
+++ b/src/JellyBox/ViewModels/ShellSearchViewModel.cs
@@ -1,10 +1,10 @@
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using JellyBox.Models;
 using JellyBox.Services;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 
 namespace JellyBox.ViewModels;
 
@@ -16,6 +16,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
     private const int SuggestionLimit = 8;
     private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(350);
 
+    private readonly ILogger<ShellSearchViewModel> _logger;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly NavigationManager _navigationManager;
     private int _searchVersion;
@@ -27,9 +28,11 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
     public ObservableCollection<SearchSuggestion> Suggestions { get; } = [];
 
     public ShellSearchViewModel(
+        ILogger<ShellSearchViewModel> logger,
         JellyfinApiClient jellyfinApiClient,
         NavigationManager navigationManager)
     {
+        _logger = logger;
         _jellyfinApiClient = jellyfinApiClient;
         _navigationManager = navigationManager;
     }
@@ -131,7 +134,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in ShellSearchViewModel.UpdateSuggestionsAsync: {ex}");
+            LogUpdateSuggestionsFailed(ex);
             ReplaceSuggestions([]);
         }
     }
@@ -164,4 +167,7 @@ internal sealed partial class ShellSearchViewModel : ObservableObject
 
         return new SearchSuggestion(hint.Name, secondaryText, hint.Id.Value);
     }
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to update search suggestions.")]
+    private partial void LogUpdateSuggestionsFailed(Exception exception);
 }

--- a/src/JellyBox/ViewModels/VideoViewModel.MediaSource.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.MediaSource.cs
@@ -148,7 +148,7 @@ internal sealed partial class VideoViewModel
 
         if (!IsSubtitleFormatSupported(subtitleTrack))
         {
-            Debug.WriteLine($"Skipping unsupported external subtitle format: {subtitleTrack.Codec} (index {subtitleTrack.Index})");
+            LogSkippingUnsupportedSubtitle(subtitleTrack.Codec, subtitleTrack.Index);
             return;
         }
 
@@ -159,13 +159,13 @@ internal sealed partial class VideoViewModel
             string? subtitleUrl = subtitleTrack.DeliveryUrl;
             if (string.IsNullOrEmpty(subtitleUrl))
             {
-                Debug.WriteLine($"Subtitle track {subtitleTrack.Index} has no delivery URL.");
+                LogSubtitleNoDeliveryUrl(subtitleTrack.Index);
                 return;
             }
 
             TimedTextSource timedTextSource = TimedTextSource.CreateFromUri(new Uri(subtitleUrl), language);
             mediaSource.ExternalTimedTextSources.Add(timedTextSource);
-            Debug.WriteLine($"Added third-party external subtitle (index {subtitleTrack.Index}): {subtitleUrl}");
+            LogAddedThirdPartySubtitle(subtitleTrack.Index, subtitleUrl);
             return;
         }
 
@@ -192,11 +192,11 @@ internal sealed partial class VideoViewModel
 
             TimedTextSource timedTextSource = TimedTextSource.CreateFromStream(stream, language);
             mediaSource.ExternalTimedTextSources.Add(timedTextSource);
-            Debug.WriteLine($"Added Jellyfin-hosted external subtitle from stream (index {subtitleTrack.Index})");
+            LogAddedJellyfinSubtitle(subtitleTrack.Index);
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Failed to download subtitle stream (index {subtitleTrack.Index}): {ex.Message}");
+            LogSubtitleDownloadFailed(ex, subtitleTrack.Index);
         }
     }
 
@@ -296,7 +296,7 @@ internal sealed partial class VideoViewModel
         double responseTimeSeconds = ((double)(Stopwatch.GetTimestamp() - startTime)) / Stopwatch.Frequency;
         double bytesPerSecond = totalBytesRead / responseTimeSeconds;
         int bitrate = (int)Math.Round(bytesPerSecond * 8 * SafetyRatio);
-        Debug.WriteLine($"Downloaded {totalBytesRead} bytes in {responseTimeSeconds:F2}s. Using max bitrate of {bitrate}");
+        LogMeasuredBitrate(totalBytesRead, responseTimeSeconds, bitrate);
         _cachedMaxStreamingBitrate = bitrate;
         return bitrate;
     }

--- a/src/JellyBox/ViewModels/VideoViewModel.Playback.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Playback.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.Input;
 using JellyBox.Controls;
 using JellyBox.Services;
@@ -24,6 +23,8 @@ internal sealed partial class VideoViewModel
             _cachedMaxStreamingBitrate = null;
             BaseItemDto item = _currentItem;
             _playerElement = playerElement;
+
+            LogPlaybackStarting(item.Name, item.Id ?? Guid.Empty);
 
             // Bind commands to transport controls
             _transportControls.PlayPauseCommand = TogglePlayPauseCommand;
@@ -134,7 +135,7 @@ internal sealed partial class VideoViewModel
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in PlayVideo: {ex}");
+            LogPlaybackError(ex, _currentItem?.Name);
         }
     }
 
@@ -145,6 +146,8 @@ internal sealed partial class VideoViewModel
             _progressTimer.Stop();
 
             UpdatePositionTicks();
+
+            LogPlaybackStopped(_currentItem?.Name, _playbackProgressInfo?.PositionTicks ?? 0);
 
             MediaPlayer? player = _playerElement?.MediaPlayer;
             if (player is not null)
@@ -188,7 +191,7 @@ internal sealed partial class VideoViewModel
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in StopVideo: {ex}");
+            LogPlaybackError(ex, _currentItem?.Name);
         }
     }
 
@@ -207,7 +210,7 @@ internal sealed partial class VideoViewModel
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error restarting playback: {ex}");
+            LogRestartPlaybackError(ex);
         }
     }
 
@@ -233,6 +236,7 @@ internal sealed partial class VideoViewModel
 
         if (mediaSourceInfo is null)
         {
+            LogNoMediaSource(_currentItem.Id ?? Guid.Empty);
             return;
         }
 
@@ -288,7 +292,7 @@ internal sealed partial class VideoViewModel
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error in ToggleFavoriteAsync: {ex}");
+            LogToggleFavoriteError(ex);
         }
     }
 }

--- a/src/JellyBox/ViewModels/VideoViewModel.PlaybackInfo.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.PlaybackInfo.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text;
 using CommunityToolkit.Mvvm.Input;
 using Jellyfin.Sdk.Generated.Models;
@@ -208,7 +207,7 @@ internal sealed partial class VideoViewModel
         }
         catch (Exception ex)
         {
-            Debug.WriteLine($"Error showing playback info: {ex}");
+            LogPlaybackInfoDialogError(ex);
         }
     }
 

--- a/src/JellyBox/ViewModels/VideoViewModel.Reporting.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Reporting.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Jellyfin.Sdk.Generated.Models;
 using Windows.Media.Playback;
 
@@ -87,7 +86,7 @@ internal sealed partial class VideoViewModel
         {
             // Timer callbacks with async void can crash the app if exceptions propagate.
             // Log and suppress to prevent app termination.
-            Debug.WriteLine($"Error in TimerTick: {ex}");
+            LogProgressReportError(ex);
         }
     }
 }

--- a/src/JellyBox/ViewModels/VideoViewModel.Tracks.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.Tracks.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using CommunityToolkit.Mvvm.Input;
 using JellyBox.Controls;
 using JellyBox.Services;
@@ -114,7 +113,7 @@ internal sealed partial class VideoViewModel
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine($"Error in OnTimedMetadataTracksChanged: {ex}");
+                    LogSubtitlePresentationError(ex);
                 }
             });
     }
@@ -135,8 +134,7 @@ internal sealed partial class VideoViewModel
         int? uwpIndex = GetSubtitleUwpIndex(selectedIndex);
         if (!uwpIndex.HasValue || uwpIndex.Value >= playbackItem.TimedMetadataTracks.Count)
         {
-            Debug.WriteLine(
-                $"Subtitle UWP index out of range for Jellyfin index {selectedIndex} (uwp={uwpIndex}, count={playbackItem.TimedMetadataTracks.Count}).");
+            LogSubtitleIndexOutOfRange(selectedIndex, uwpIndex, playbackItem.TimedMetadataTracks.Count);
             return;
         }
 
@@ -168,12 +166,12 @@ internal sealed partial class VideoViewModel
             && track.UwpTrackIndex.Value < _currentPlaybackItem.AudioTracks.Count)
         {
             _currentPlaybackItem.AudioTracks.SelectedIndex = track.UwpTrackIndex.Value;
-            Debug.WriteLine($"Seamless audio track switch to Jellyfin index {track.JellyfinIndex} (UWP index {track.UwpTrackIndex})");
+            LogSeamlessAudioSwitch(track.JellyfinIndex, track.UwpTrackIndex);
             return;
         }
 
         // Fall back to restarting playback (e.g., for transcoding scenarios)
-        Debug.WriteLine($"Restarting playback for audio track {track.JellyfinIndex}");
+        LogRestartForAudioTrack(track.JellyfinIndex);
         RestartPlaybackWithCurrentPosition();
     }
 
@@ -192,14 +190,12 @@ internal sealed partial class VideoViewModel
         if (canSeamlessSwitch)
         {
             PresentSelectedSubtitleTrack(_currentPlaybackItem!);
-            Debug.WriteLine(track.UwpTrackIndex.HasValue
-                ? $"Seamless subtitle switch to Jellyfin index {track.JellyfinIndex} (UWP index {track.UwpTrackIndex})"
-                : "Subtitles disabled");
+            LogSeamlessSubtitleSwitch(track.JellyfinIndex, track.UwpTrackIndex);
             return;
         }
 
         // Fall back to restarting playback (e.g., switching unloaded external tracks, transcoding, unsupported formats)
-        Debug.WriteLine($"Restarting playback for subtitle track {track.JellyfinIndex}");
+        LogRestartForSubtitleTrack(track.JellyfinIndex);
         RestartPlaybackWithCurrentPosition();
     }
 

--- a/src/JellyBox/ViewModels/VideoViewModel.cs
+++ b/src/JellyBox/ViewModels/VideoViewModel.cs
@@ -3,6 +3,7 @@ using JellyBox.Controls;
 using JellyBox.Services;
 using Jellyfin.Sdk;
 using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Kiota.Abstractions;
 using Windows.Media.Playback;
 using Windows.UI.Xaml;
@@ -14,6 +15,7 @@ namespace JellyBox.ViewModels;
 internal sealed partial class VideoViewModel : ObservableObject
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
 {
+    private readonly ILogger<VideoViewModel> _logger;
     private readonly JellyfinApiClient _jellyfinApiClient;
     private readonly IRequestAdapter _requestAdapter;
     private readonly JellyfinImageResolver _imageResolver;
@@ -31,12 +33,14 @@ internal sealed partial class VideoViewModel : ObservableObject
     private int? _cachedMaxStreamingBitrate;
 
     public VideoViewModel(
+        ILogger<VideoViewModel> logger,
         JellyfinApiClient jellyfinApiClient,
         IRequestAdapter requestAdapter,
         JellyfinImageResolver imageResolver,
         JellyfinSdkSettings sdkClientSettings,
         DeviceProfileManager deviceProfileManager)
     {
+        _logger = logger;
         _jellyfinApiClient = jellyfinApiClient;
         _requestAdapter = requestAdapter;
         _imageResolver = imageResolver;
@@ -53,4 +57,64 @@ internal sealed partial class VideoViewModel : ObservableObject
     public Uri? BackdropImageUri { get; set => SetProperty(ref field, value); }
 
     public bool ShowBackdropImage { get; set => SetProperty(ref field, value); }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Starting playback of \"{ItemName}\" ({ItemId}).")]
+    private partial void LogPlaybackStarting(string? itemName, Guid itemId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Stopped playback of \"{ItemName}\" at {PositionTicks} ticks.")]
+    private partial void LogPlaybackStopped(string? itemName, long positionTicks);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No playable media source returned for item {ItemId}.")]
+    private partial void LogNoMediaSource(Guid itemId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Playback error for \"{ItemName}\".")]
+    private partial void LogPlaybackError(Exception exception, string? itemName);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to present subtitle track.")]
+    private partial void LogSubtitlePresentationError(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Subtitle UWP index out of range for Jellyfin index {JellyfinIndex} (UWP index {UwpIndex}, track count {TrackCount}).")]
+    private partial void LogSubtitleIndexOutOfRange(int jellyfinIndex, int? uwpIndex, int trackCount);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Seamless audio track switch to Jellyfin index {JellyfinIndex} (UWP index {UwpIndex}).")]
+    private partial void LogSeamlessAudioSwitch(int jellyfinIndex, int? uwpIndex);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Restarting playback for audio track {JellyfinIndex}.")]
+    private partial void LogRestartForAudioTrack(int jellyfinIndex);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Seamless subtitle switch to Jellyfin index {JellyfinIndex} (UWP index {UwpIndex}).")]
+    private partial void LogSeamlessSubtitleSwitch(int jellyfinIndex, int? uwpIndex);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Restarting playback for subtitle track {JellyfinIndex}.")]
+    private partial void LogRestartForSubtitleTrack(int jellyfinIndex);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to report playback progress.")]
+    private partial void LogProgressReportError(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to show playback info dialog.")]
+    private partial void LogPlaybackInfoDialogError(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to restart playback.")]
+    private partial void LogRestartPlaybackError(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to toggle favorite state.")]
+    private partial void LogToggleFavoriteError(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Skipping unsupported external subtitle format {Codec} (index {Index}).")]
+    private partial void LogSkippingUnsupportedSubtitle(string? codec, int? index);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Subtitle track {Index} has no delivery URL.")]
+    private partial void LogSubtitleNoDeliveryUrl(int? index);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Added third-party external subtitle (index {Index}): {SubtitleUrl}.")]
+    private partial void LogAddedThirdPartySubtitle(int? index, string subtitleUrl);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Added Jellyfin-hosted external subtitle from stream (index {Index}).")]
+    private partial void LogAddedJellyfinSubtitle(int? index);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to download subtitle stream (index {Index}).")]
+    private partial void LogSubtitleDownloadFailed(Exception exception, int? index);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Measured max streaming bitrate {Bitrate} bps ({TotalBytes} bytes downloaded in {ResponseTimeSeconds}s).")]
+    private partial void LogMeasuredBitrate(long totalBytes, double responseTimeSeconds, int bitrate);
 }


### PR DESCRIPTION
## Summary

This adds a persistent `Microsoft.Extensions.Logging` foundation for JellyBox so diagnostics from sideloaded UWP/Xbox builds survive beyond debugger/console output. A custom rotating file `ILoggerProvider` writes to the app's `ApplicationData.Current.LocalFolder\logs` folder for Device Portal retrieval, is registered through DI, and is flushed during crash/suspend paths. Representative app, auth, navigation, library/search/item, and playback diagnostics now use injected `ILogger<T>` with CA1848-compliant `[LoggerMessage]` source-generated methods.

## Why this is safe

- The sink is dependency-light: no new NuGet packages, app-local storage only, 4 MiB log rotation with 3 retained files, and non-blocking normal enqueue so logging does not stall app threads.
- Crash and suspend paths use a bounded synchronous flush so recent entries are persisted without an unbounded hang.
- Registration is additive: the existing console provider remains, and the concrete `FileLoggerProvider` singleton is the same instance used by the logging factory and flush path.
- Log messages capture breadcrumbs and failures without passwords or access tokens; verbose playback traces are `Debug` level and remain silent with the default `Information` minimum level.
- Unobserved task exceptions are logged and marked observed so they do not terminate the process after capture.

## Validation

| Test / build | Result |
|---|---|
| `msbuild JellyBox.sln -t:Build -p:Configuration=Debug -p:Platform=x64` | Passed locally; build succeeded with 0 warnings and 0 errors. |
| Unit tests | Not run; this repository has no test project. |

## Out of scope

- This is the logging foundation only; full call-site coverage, log-level UI, share-logs UX, and crash-reporting/telemetry service integration remain future work.
- Heads-up: open PR #101 also touches `App.xaml.cs` and `AppServices.cs`; this PR's edits there are limited to additive logging registration/lifecycle hooks, so a small rebase may be needed.

## Linked issues / todos

- Related: #1 (MVP checklist Logging item)
